### PR TITLE
Small refactoring of VertexBufferLayout and attributes

### DIFF
--- a/map/src/feature_processor.rs
+++ b/map/src/feature_processor.rs
@@ -228,7 +228,6 @@ impl FeatureProcessor for ShashlikFeatureProcessor {
                         geometry_type,
                         style_id,
                         index_layer_level: layer_level as i8,
-                        is_screen: false,
                     }));
                 }
 

--- a/map/src/puck_group.rs
+++ b/map/src/puck_group.rs
@@ -16,7 +16,6 @@ impl RenderGroup for SimplePuck {
                 geometry_type: GeometryType::Polygon,
                 style_id: StyleId("puck_style"),
                 index_layer_level: 0,
-                is_screen: false,
             },
         );
     }

--- a/map/src/route/route_group.rs
+++ b/map/src/route/route_group.rs
@@ -56,7 +56,6 @@ impl RenderGroup for RouteGroup {
             geometry_type: GeometryType::Polyline(options),
             style_id,
             index_layer_level: 0,
-            is_screen: false,
         });
     }
 }

--- a/renderer/src/canvas_api.rs
+++ b/renderer/src/canvas_api.rs
@@ -113,7 +113,7 @@ impl CanvasApi {
         }
     }
 
-    fn mesh2d(&mut self, is_screen: bool) {
+    fn mesh2d(&mut self) {
         let mesh = mem::replace(&mut self.geometry, VertexBuffers::new());
         if !mesh.vertices.is_empty() {
             let flatten_ranges = mem::take(&mut self.indices_by_layers)
@@ -124,7 +124,7 @@ impl CanvasApi {
                 instance_positions: vec![Vector3::new(0.0, 0.0, 0.0)],
                 with_collision: false,
             };
-            self.mesh2d_with_positions(mesh, flatten_ranges, mesh_info, is_screen);
+            self.mesh2d_with_positions(mesh, flatten_ranges, mesh_info, false);
         }
     }
 
@@ -141,7 +141,6 @@ impl CanvasApi {
             layers_indices,
             mesh_info,
             is_screen,
-            outlined: !is_screen,
             feature_layer_tag: self.feature_layer_tag.clone(),
         }));
     }
@@ -251,11 +250,6 @@ impl CanvasApi {
         } else {
             ranges.push(initial_index..last_index);
         }
-
-        // TODO It should aggregate geometry for "screen" type layers
-        if data.is_screen {
-            self.mesh2d(true);
-        }
     }
 
     fn svg(&mut self, data: SvgData) {
@@ -286,7 +280,7 @@ impl CanvasApi {
         assert!(!self.flushed);
         self.flushed = true;
 
-        self.mesh2d(false);
+        self.mesh2d();
 
         let mesh3d = mem::replace(&mut self.geometry3d, VertexBuffers::new());
         if mesh3d.vertices.len() > 0 {

--- a/renderer/src/draw_commands/mesh2d_draw_command.rs
+++ b/renderer/src/draw_commands/mesh2d_draw_command.rs
@@ -14,7 +14,6 @@ pub(crate) struct Mesh2dDrawCommand {
     pub layers_indices: Vec<Range<usize>>,
     pub mesh_info: MeshInfo,
     pub is_screen: bool,
-    pub outlined: bool,
     pub feature_layer_tag: Option<String>,
 }
 
@@ -33,7 +32,7 @@ impl DrawCommand for Mesh2dDrawCommand {
             device,
             mem::take(&mut self.mesh_info.instance_positions),
             0.0,
-            spatial_rx, self.outlined,
+            spatial_rx, !self.is_screen,
             self.mesh_info.with_collision,
         );
 

--- a/renderer/src/geometry_data.rs
+++ b/renderer/src/geometry_data.rs
@@ -18,7 +18,6 @@ pub struct ShapeData {
     pub geometry_type: GeometryType,
     pub style_id: StyleId,
     pub index_layer_level: i8,
-    pub is_screen: bool // might not be the best idea
 }
 
 #[derive(Clone)]

--- a/renderer/src/lib.rs
+++ b/renderer/src/lib.rs
@@ -17,7 +17,7 @@ use crate::nodes::world::World;
 use crate::pipeline_provider::PipeLineProvider;
 use crate::styles::style_store::StyleStore;
 use crate::text::text_renderer::{TextRenderer, TextRendererLayer};
-use crate::vertex_attrs::{InstanceInput, ShapeVertex, VertexAttrib, VertexNormal};
+use crate::vertex_attrs::{InstanceInput, ShapeVertex, TextInstanceInput, VertexAttrib, VertexNormal};
 use crate::view_projection::ViewProjection;
 use canvas_api::CanvasApi;
 use cgmath::{Matrix4, Vector2, Vector3};
@@ -202,7 +202,7 @@ impl ShashlikRenderer {
         let text_layer = MeshLayer::new(
             &device,
             include_wgsl!("shaders/text_shader.wgsl"),
-            Rc::new([VertexNormal::desc(), InstanceInput::desc()]),
+            Rc::new([VertexNormal::desc(), TextInstanceInput::desc()]),
             pipeline_provider.clone(),
             None,
             CompareFunction::Always,

--- a/renderer/src/nodes/mesh_node.rs
+++ b/renderer/src/nodes/mesh_node.rs
@@ -146,7 +146,7 @@ impl PositionedMesh {
             let item = original_positions_alpha[i];
 
             let transform_with_cs_offset = item.0 + spatial_data.transform - cs_offset;
-            let instance_pos = InstanceInput {
+            let instance_input = InstanceInput {
                 position: transform_with_cs_offset.cast().unwrap().into(),
                 color_alpha: item.1,
                 matrix: matrix.cast().unwrap().into(),
@@ -157,11 +157,10 @@ impl PositionedMesh {
                     spatial_data.size.1.round() as f32,
                 ],
                 normal_scale: spatial_data.normal_scale as f32,
-                screen_space: 0,
             };
-            attrs.push(instance_pos);
+            attrs.push(instance_input);
             if is_two_instances {
-                attrs.push(instance_pos);
+                attrs.push(instance_input);
             }
         }
     }

--- a/renderer/src/shaders/mesh_shader.wgsl
+++ b/renderer/src/shaders/mesh_shader.wgsl
@@ -21,7 +21,6 @@ struct InstanceInput {
     @location(9) model_matrix_3: vec4<f32>,
     @location(10) bbox: vec4<f32>,
     @location(11) normal_scale: f32,
-    @location(12) screen_space: u32,
 }
 
 struct VertexOutput {

--- a/renderer/src/shaders/screen_shape_shader.wgsl
+++ b/renderer/src/shaders/screen_shape_shader.wgsl
@@ -34,7 +34,6 @@ struct InstanceInput {
     @location(9) model_matrix_3: vec4<f32>,
     @location(10) bbox: vec4<f32>,
     @location(11) normal_scale: f32,
-    @location(12) screen_space: u32,
 }
 
 struct VertexOutput {

--- a/renderer/src/shaders/shape_shader.wgsl
+++ b/renderer/src/shaders/shape_shader.wgsl
@@ -34,7 +34,6 @@ struct InstanceInput {
     @location(9) model_matrix_3: vec4<f32>,
     @location(10) bbox: vec4<f32>,
     @location(11) normal_scale: f32,
-    @location(12) screen_space: u32,
 }
 
 struct VertexOutput {

--- a/renderer/src/shaders/text_shader.wgsl
+++ b/renderer/src/shaders/text_shader.wgsl
@@ -19,9 +19,7 @@ struct InstanceInput {
     @location(7) model_matrix_1: vec4<f32>,
     @location(8) model_matrix_2: vec4<f32>,
     @location(9) model_matrix_3: vec4<f32>,
-    @location(10) bbox: vec4<f32>,
-    @location(11) normal_scale: f32,
-    @location(12) screen_space: u32,
+    @location(12) screen_space: u32, // question: should the location be universal across
 }
 
 struct VertexOutput {

--- a/renderer/src/text/text_renderer.rs
+++ b/renderer/src/text/text_renderer.rs
@@ -1,7 +1,7 @@
 use crate::collision_handler::CollisionHandler;
 use crate::nodes::SceneNode;
 use crate::text::default_face_wrapper::DefaultFaceWrapper;
-use crate::vertex_attrs::InstanceInput;
+use crate::vertex_attrs::TextInstanceInput;
 use crate::view_projection::ViewProjection;
 use crate::GlobalContext;
 use cgmath::num_traits::clamp;
@@ -302,15 +302,13 @@ impl TextRenderer {
                 if !glyph_data.screen_space {
                     position -= vec3(cs_offset.x as f32, cs_offset.y as f32, 0.0)
                 }
-                let instance_pos = InstanceInput {
+                let instance_input = TextInstanceInput {
                     position: position.into(),
                     color_alpha: glyph_data.alpha,
                     matrix: glyph_data.matrix.cast().unwrap().into(),
-                    bbox: [0.0, 0.0, 0.0, 0.0],
-                    normal_scale: 1f32,
                     screen_space: glyph_data.screen_space.into(),
                 };
-                attrs.push(instance_pos);
+                attrs.push(instance_input);
             });
 
             let attrs_len = attrs.len();
@@ -331,7 +329,7 @@ impl TextRenderer {
         });
     }
 
-    fn create_instance_buffer(device: &Device, instances: &Vec<InstanceInput>) -> Buffer {
+    fn create_instance_buffer(device: &Device, instances: &Vec<TextInstanceInput>) -> Buffer {
         device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("Instance Buffer"),
             contents: bytemuck::cast_slice(instances.as_slice()),

--- a/renderer/src/vertex_attrs.rs
+++ b/renderer/src/vertex_attrs.rs
@@ -1,7 +1,17 @@
-use wgpu::{VertexAttribute, VertexBufferLayout};
+use std::mem;
+use wgpu::{BufferAddress, VertexAttribute, VertexStepMode};
 
-pub trait VertexAttrib {
-    fn desc() -> wgpu::VertexBufferLayout<'static>;
+pub trait VertexAttrib: Sized {
+    const ATTRIBUTES: &[VertexAttribute];
+    const STEP_MODE: wgpu::VertexStepMode;
+
+    fn desc() -> wgpu::VertexBufferLayout<'static> {
+        wgpu::VertexBufferLayout {
+            array_stride: mem::size_of::<Self>() as BufferAddress,
+            step_mode: Self::STEP_MODE,
+            attributes: Self::ATTRIBUTES,
+        }
+    }
 }
 
 #[repr(C)]
@@ -14,16 +24,10 @@ pub struct ShapeVertex {
 }
 
 impl VertexAttrib for ShapeVertex {
-    fn desc() -> wgpu::VertexBufferLayout<'static> {
-        const ATTRIBUTES: &[VertexAttribute; 4] =
-            &wgpu::vertex_attr_array![0 => Float32x3, 1 => Float32x3, 2 => Float32, 3 => Uint32];
-        use std::mem;
-        wgpu::VertexBufferLayout {
-            array_stride: mem::size_of::<Self>() as wgpu::BufferAddress,
-            step_mode: wgpu::VertexStepMode::Vertex,
-            attributes: ATTRIBUTES,
-        }
-    }
+    const ATTRIBUTES: &[VertexAttribute] =
+        &wgpu::vertex_attr_array![0 => Float32x3, 1 => Float32x3, 2 => Float32, 3 => Uint32];
+
+    const STEP_MODE: VertexStepMode = wgpu::VertexStepMode::Vertex;
 }
 
 #[repr(C)]
@@ -34,17 +38,10 @@ pub struct VertexNormal {
 }
 
 impl VertexAttrib for VertexNormal {
-    fn desc() -> wgpu::VertexBufferLayout<'static> {
-        const ATTRIBUTES: &[VertexAttribute; 2] =
-            &wgpu::vertex_attr_array![0 => Float32x3, 1 => Float32x3];
+    const ATTRIBUTES: &[VertexAttribute] =
+        &wgpu::vertex_attr_array![0 => Float32x3, 1 => Float32x3];
 
-        use std::mem;
-        wgpu::VertexBufferLayout {
-            array_stride: mem::size_of::<Self>() as wgpu::BufferAddress,
-            step_mode: wgpu::VertexStepMode::Vertex,
-            attributes: ATTRIBUTES,
-        }
-    }
+    const STEP_MODE: VertexStepMode = wgpu::VertexStepMode::Vertex;
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
@@ -54,28 +51,42 @@ pub struct InstanceInput {
     pub(crate) matrix: [[f32; 4]; 4],
     pub(crate) bbox: [f32; 4],
     pub(crate) normal_scale: f32,
-    pub(crate) screen_space: u32,
 }
 
 impl VertexAttrib for InstanceInput {
-    fn desc() -> VertexBufferLayout<'static> {
-        const ATTRIBUTES: &[VertexAttribute; 9] = &wgpu::vertex_attr_array![
-            4 => Float32x3,
-            5 => Float32,
-            6 => Float32x4,
-            7 => Float32x4,
-            8 => Float32x4,
-            9 => Float32x4,
-            10 => Float32x4,
-            11 => Float32,
-            12 => Uint32,
-        ];
+    const ATTRIBUTES: &[VertexAttribute] = &wgpu::vertex_attr_array![
+        4 => Float32x3,
+        5 => Float32,
+        6 => Float32x4,
+        7 => Float32x4,
+        8 => Float32x4,
+        9 => Float32x4,
+        10 => Float32x4,
+        11 => Float32,
+    ];
 
-        wgpu::VertexBufferLayout {
-            array_stride: size_of::<Self>() as wgpu::BufferAddress,
-            // It's easy to forget it should be VertexStepMode::Instance!
-            step_mode: wgpu::VertexStepMode::Instance,
-            attributes: ATTRIBUTES,
-        }
-    }
+    const STEP_MODE: VertexStepMode = wgpu::VertexStepMode::Instance;
 }
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
+pub struct TextInstanceInput {
+    pub(crate) position: [f32; 3],
+    pub(crate) color_alpha: f32,
+    pub(crate) matrix: [[f32; 4]; 4],
+    pub(crate) screen_space: u32,
+}
+impl VertexAttrib for TextInstanceInput {
+    const ATTRIBUTES: &[VertexAttribute] = &wgpu::vertex_attr_array![
+        4 => Float32x3,
+        5 => Float32,
+        6 => Float32x4,
+        7 => Float32x4,
+        8 => Float32x4,
+        9 => Float32x4,
+        12 => Uint32,
+    ];
+
+    const STEP_MODE: VertexStepMode = wgpu::VertexStepMode::Instance;
+}
+


### PR DESCRIPTION
Two major changes:
- to simplify approach to create a new vertex attribute
- text renderer uses its own instance input