### PR TITLE
Reduce buffers creation for instance meshes + some refactoring

### DIFF
--- a/renderer/src/draw_commands/mesh2d_draw_command.rs
+++ b/renderer/src/draw_commands/mesh2d_draw_command.rs
@@ -1,5 +1,6 @@
 use crate::canvas_api::MeshInfo;
-use crate::draw_commands::{DrawCommand, geometry_to_mesh_with_layers};
+use crate::draw_commands::DrawCommand;
+use crate::mesh::mesh::Mesh;
 use crate::mesh_layers::layers::Layers;
 use crate::modifier::render_modifier::SpatialData;
 use crate::vertex_attrs::ShapeVertex;
@@ -25,16 +26,13 @@ impl DrawCommand for Mesh2dDrawCommand {
         spatial_rx: tokio::sync::broadcast::Receiver<SpatialData>,
         layers: &mut Layers,
     ) {
-        // TODO Mesh bufs still need to created all the time even though it makes no sense for 
-        //  screen_shape_layer. Should it be moved anywhere else?
-        let mesh =
-            geometry_to_mesh_with_layers(&device, &self.mesh, mem::take(&mut self.layers_indices));
-
         if let Some(feature_layer) = self
             .feature_layer_tag
             .as_ref()
             .and_then(|tag| layers.feature_layers(tag))
         {
+            let mesh =
+                Mesh::create_layered(&device, &self.mesh, mem::take(&mut self.layers_indices));
             feature_layer.add(
                 key,
                 mem::take(&mut self.mesh_info.instance_positions),
@@ -43,11 +41,12 @@ impl DrawCommand for Mesh2dDrawCommand {
                 mesh,
             );
         } else if self.is_screen {
-            // TODO check mesh collision
-            layers.screen_shape_layer.submit(key,
-                                             self.mesh_info.instance_key.as_str(),
-                                             mem::take(&mut self.mesh_info.instance_positions).unwrap_or_default(), spatial_data, mesh);
+            layers
+                .screen_shape_layer
+                .submit(key.as_str(), spatial_data, device, self);
         } else {
+            let mesh =
+                Mesh::create_layered(&device, &self.mesh, mem::take(&mut self.layers_indices));
             layers.shape_layer.add(
                 key,
                 mem::take(&mut self.mesh_info.instance_positions),

--- a/renderer/src/draw_commands/mesh3d_draw_command.rs
+++ b/renderer/src/draw_commands/mesh3d_draw_command.rs
@@ -1,4 +1,5 @@
-use crate::draw_commands::{DrawCommand, MeshVertex, geometry_to_mesh};
+use crate::draw_commands::{DrawCommand, MeshVertex};
+use crate::mesh::mesh::Mesh;
 use crate::mesh_layers::layers::Layers;
 use crate::modifier::render_modifier::SpatialData;
 use lyon::lyon_tessellation::VertexBuffers;
@@ -17,9 +18,7 @@ impl DrawCommand for Mesh3dDrawCommand {
         spatial_rx: tokio::sync::broadcast::Receiver<SpatialData>,
         layers: &mut Layers,
     ) {
-        let mesh = geometry_to_mesh(&device, &self.mesh);
-        layers
-            .mesh_layer
-            .add(key, None, spatial_rx, false, mesh);
+        let mesh = Mesh::create(&device, &self.mesh);
+        layers.mesh_layer.add(key, None, spatial_rx, false, mesh);
     }
 }

--- a/renderer/src/draw_commands/mod.rs
+++ b/renderer/src/draw_commands/mod.rs
@@ -3,14 +3,9 @@ pub mod mesh3d_draw_command;
 pub mod text_draw_command;
 
 use crate::mesh_layers::layers::Layers;
-use crate::mesh::mesh::Mesh;
 use crate::modifier::render_modifier::SpatialData;
-use bytemuck::NoUninit;
-use lyon::lyon_tessellation::{LineJoin, VertexBuffers};
-use std::ops::Range;
+use lyon::lyon_tessellation::LineJoin;
 use lyon::path::LineCap;
-use wgpu::util::{BufferInitDescriptor, DeviceExt};
-use wgpu::Device;
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
@@ -94,31 +89,4 @@ pub(crate) trait DrawCommand: Send {
         spatial_rx: tokio::sync::broadcast::Receiver<SpatialData>,
         layers: &mut Layers
     );
-}
-
-pub fn geometry_to_mesh<T: NoUninit>(device: &Device, geometry: &VertexBuffers<T, u32>) -> Mesh {
-    geometry_to_mesh_with_layers(device, geometry, vec![0..geometry.indices.len()])
-}
-fn geometry_to_mesh_with_layers<T: NoUninit>(
-    device: &Device,
-    geometry: &VertexBuffers<T, u32>,
-    layers_indices: Vec<Range<usize>>,
-) -> Mesh {
-    let vertex_buffer = device.create_buffer_init(&BufferInitDescriptor {
-        label: Some("Vertex Buffer"),
-        contents: bytemuck::cast_slice(geometry.vertices.as_slice()),
-        usage: wgpu::BufferUsages::VERTEX,
-    });
-    let index_buffer = device.create_buffer_init(&BufferInitDescriptor {
-        label: Some("Index Buffer"),
-        contents: bytemuck::cast_slice(geometry.indices.as_slice()),
-        usage: wgpu::BufferUsages::INDEX,
-    });
-    let num_indices = geometry.indices.len() as u32;
-
-    Mesh::new(
-        vec![vertex_buffer],
-        vec![(index_buffer, num_indices as usize)],
-        layers_indices,
-    )
 }

--- a/renderer/src/mesh/mesh.rs
+++ b/renderer/src/mesh/mesh.rs
@@ -1,6 +1,10 @@
 use std::ops::Range;
+use bytemuck::{NoUninit, Pod};
 use log::error;
-use wgpu::{Buffer, RenderPass};
+use lyon::lyon_tessellation::VertexBuffers;
+use wgpu::{Buffer, Device, RenderPass};
+use wgpu::util::{BufferInitDescriptor, DeviceExt};
+use crate::mesh::InstanceBuffer;
 
 pub struct Mesh {
     pub vertex_buf: Vec<Buffer>,
@@ -17,6 +21,41 @@ impl Mesh {
             vertex_buf: v_buf,
             index_buf: i_buf,
             layers_indices
+        }
+    }
+
+    pub fn create<T: NoUninit>(device: &Device,
+                               geometry: &VertexBuffers<T, u32>) -> Self {
+        Self::create_layered(device, geometry, vec![0..geometry.indices.len()])
+    }
+
+    pub fn create_layered<T: NoUninit>(device: &Device,
+                                       geometry: &VertexBuffers<T, u32>,
+                                       layers_indices: Vec<Range<usize>>) -> Self {
+        let vertex_buffer = device.create_buffer_init(&BufferInitDescriptor {
+            label: Some("Vertex Buffer"),
+            contents: bytemuck::cast_slice(geometry.vertices.as_slice()),
+            usage: wgpu::BufferUsages::VERTEX,
+        });
+        let index_buffer = device.create_buffer_init(&BufferInitDescriptor {
+            label: Some("Index Buffer"),
+            contents: bytemuck::cast_slice(geometry.indices.as_slice()),
+            usage: wgpu::BufferUsages::INDEX,
+        });
+        let num_indices = geometry.indices.len() as u32;
+
+        Mesh::new(
+            vec![vertex_buffer],
+            vec![(index_buffer, num_indices as usize)],
+            layers_indices,
+        )
+    }
+
+    pub fn render_instanced<T: Pod>(&self, slot: u32, render_pass: &mut RenderPass, instance_buffer: &InstanceBuffer<T>) {
+        if let Some(buffer) = instance_buffer.buffer.as_ref() {
+            render_pass.set_vertex_buffer(slot, buffer.slice(..));
+            let range = 0u32..instance_buffer.length as u32;
+            self.render(render_pass, &range);
         }
     }
 

--- a/renderer/src/mesh/positioned_mesh.rs
+++ b/renderer/src/mesh/positioned_mesh.rs
@@ -87,10 +87,6 @@ impl<T: MeshInstanceInput> PositionedMesh<T> {
     }
 
     pub fn render(&mut self, render_pass: &mut RenderPass) {
-        if let Some(buffer) = self.instance_buffer.buffer.as_ref() {
-            render_pass.set_vertex_buffer(1, buffer.slice(..));
-            let range = 0u32..self.instance_buffer.length as u32;
-            self.mesh.render(render_pass, &range);
-        }
+        self.mesh.render_instanced(1, render_pass, &self.instance_buffer);
     }
 }

--- a/renderer/src/mesh_layers/render_data_holder.rs
+++ b/renderer/src/mesh_layers/render_data_holder.rs
@@ -1,4 +1,4 @@
-use linked_hash_map::{Entry, LinkedHashMap};
+use linked_hash_map::LinkedHashMap;
 
 pub struct RenderDataHolder<T> {
     holder: LinkedHashMap<String, Vec<T>>,
@@ -12,12 +12,7 @@ impl<T> RenderDataHolder<T> {
     }
 
     pub fn add(&mut self, key: String, data: T) {
-        match self.holder.entry(key) {
-            Entry::Occupied(mut entry) => entry.get_mut().push(data),
-            Entry::Vacant(entry) => {
-                entry.insert(vec![data]);
-            }
-        };
+        self.holder.entry(key).or_default().push(data);
     }
 
     pub fn remove(&mut self, key: &str) {

--- a/renderer/src/mesh_layers/screen_mesh_layer.rs
+++ b/renderer/src/mesh_layers/screen_mesh_layer.rs
@@ -1,3 +1,4 @@
+use crate::draw_commands::mesh2d_draw_command::Mesh2dDrawCommand;
 use crate::global_context::GlobalContext;
 use crate::mesh::InstanceBuffer;
 use crate::mesh::mesh::Mesh;
@@ -11,11 +12,11 @@ use cgmath::num_traits::clamp;
 use geo_types::point;
 use rstar::primitives::Rectangle;
 use std::collections::HashMap;
-use std::collections::hash_map::Entry;
-use wgpu::RenderPass;
+use std::mem;
+use wgpu::{Device, RenderPass};
 
 // TODO ScreenMeshLayer and GeneralMeshLayer could be combined somehow.
-pub struct ScreenMeshLayer<P: RenderPipeline> {
+pub(crate) struct ScreenMeshLayer<P: RenderPipeline> {
     render_pipeline: P,
     pipeline: Option<wgpu::RenderPipeline>,
     meshes: HashMap<String, (Mesh, InstanceBuffer<P::InstanceInputType>)>,
@@ -31,22 +32,32 @@ impl<P: RenderPipeline> ScreenMeshLayer<P> {
             instance_data: RenderDataHolder::new(),
         }
     }
+
     pub fn submit(
         &mut self,
-        key: String,
-        instance_key: &str,
-        instance_positions: Vec<Vector3<f64>>,
+        key: &str,
         spatial_data: SpatialData,
-        mesh: Mesh,
+        device: &Device,
+        command: &mut Mesh2dDrawCommand,
     ) {
-        self.meshes
-            .entry(instance_key.to_string())
-            .or_insert((mesh, InstanceBuffer::default()));
+        let instance_key = command.mesh_info.instance_key.to_string();
+        self.meshes.entry(instance_key.clone()).or_insert({
+            (
+                Mesh::create_layered(
+                    &device,
+                    &command.mesh,
+                    mem::take(&mut command.layers_indices),
+                ),
+                InstanceBuffer::default(),
+            )
+        });
 
+        let instance_positions =
+            mem::take(&mut command.mesh_info.instance_positions).unwrap_or_default();
         instance_positions.into_iter().for_each(|item| {
             self.instance_data.add(
-                key.clone(),
-                (item + spatial_data.transform, 0.0, instance_key.to_string()),
+                key.to_string(),
+                (item + spatial_data.transform, 0.0, instance_key.clone()),
             );
         });
     }
@@ -80,12 +91,7 @@ impl<P: RenderPipeline> BaseMeshLayer for ScreenMeshLayer<P> {
                 }
             }
 
-            match hm.entry(key.clone()) {
-                Entry::Occupied(mut entry) => entry.get_mut().push((*pos, *alpha)),
-                Entry::Vacant(entry) => {
-                    entry.insert(vec![(*pos, *alpha)]);
-                }
-            };
+            hm.entry(key.clone()).or_default().push((*pos, *alpha));
         });
 
         let cs_offset = global_context.view_projection.cs_offset;
@@ -120,11 +126,7 @@ impl<P: RenderPipeline> BaseMeshLayer for ScreenMeshLayer<P> {
             self.render_pipeline.render(render_pass, global_context);
 
             self.meshes.iter().for_each(|(_, (mesh, instance_buf))| {
-                if let Some(buf) = instance_buf.buffer.as_ref() {
-                    render_pass.set_vertex_buffer(1, buf.slice(..));
-                    let range = 0u32..instance_buf.length as u32;
-                    mesh.render(render_pass, &range);
-                }
+                mesh.render_instanced(1, render_pass, instance_buf);
             });
         }
     }

--- a/renderer/src/text/default_face_wrapper.rs
+++ b/renderer/src/text/default_face_wrapper.rs
@@ -1,4 +1,3 @@
-use crate::draw_commands::geometry_to_mesh;
 use crate::mesh::mesh::Mesh;
 use crate::text::glyph_tesselator::GlyphTesselator;
 use cgmath::{Matrix4, Vector2};
@@ -44,7 +43,7 @@ impl DefaultFaceWrapper {
             let glyph_buf = path_builder.tessellate_fill(Vector2::new(0.0, 0.0f32), Color::RED);
             glyph_mesh_map.insert(
                 GlyphId(glyph_info.glyph_id as u16),
-                geometry_to_mesh(device, &glyph_buf),
+                Mesh::create(&device, &glyph_buf),
             );
         }
 


### PR DESCRIPTION
No need to create a new wgpu Buffer for each "icon" mesh.