### PR TITLE
More InstanceBuffer optimization

### DIFF
--- a/renderer/src/draw_commands/mesh2d_draw_command.rs
+++ b/renderer/src/draw_commands/mesh2d_draw_command.rs
@@ -35,7 +35,6 @@ impl DrawCommand for Mesh2dDrawCommand {
                 Mesh::create_layered(&device, &self.mesh, mem::take(&mut self.layers_indices));
             feature_layer.add(
                 key,
-                mem::take(&mut self.mesh_info.instance_positions),
                 spatial_rx,
                 !self.is_screen,
                 mesh,
@@ -49,7 +48,6 @@ impl DrawCommand for Mesh2dDrawCommand {
                 Mesh::create_layered(&device, &self.mesh, mem::take(&mut self.layers_indices));
             layers.shape_layer.add(
                 key,
-                mem::take(&mut self.mesh_info.instance_positions),
                 spatial_rx,
                 !self.is_screen,
                 mesh,

--- a/renderer/src/draw_commands/mesh3d_draw_command.rs
+++ b/renderer/src/draw_commands/mesh3d_draw_command.rs
@@ -19,6 +19,6 @@ impl DrawCommand for Mesh3dDrawCommand {
         layers: &mut Layers,
     ) {
         let mesh = Mesh::create(&device, &self.mesh);
-        layers.mesh_layer.add(key, None, spatial_rx, false, mesh);
+        layers.mesh_layer.add(key, spatial_rx, false, mesh);
     }
 }

--- a/renderer/src/mesh/mesh.rs
+++ b/renderer/src/mesh/mesh.rs
@@ -52,7 +52,7 @@ impl Mesh {
     }
 
     pub fn render_instanced<T: Pod>(&self, slot: u32, render_pass: &mut RenderPass, instance_buffer: &InstanceBuffer<T>) {
-        if let Some(buffer) = instance_buffer.buffer.as_ref() {
+        if instance_buffer.length > 0 && let Some(buffer) = instance_buffer.buffer.as_ref() {
             render_pass.set_vertex_buffer(slot, buffer.slice(..));
             let range = 0u32..instance_buffer.length as u32;
             self.render(render_pass, &range);

--- a/renderer/src/mesh/mesh_instance_input.rs
+++ b/renderer/src/mesh/mesh_instance_input.rs
@@ -15,6 +15,9 @@ pub trait MeshInstanceInput: Sized + Pod {
         let matrix = spatial_data.scale_rot_matrix();
         for i in 0..original_positions_alpha.len() {
             let item = original_positions_alpha[i];
+            if item.1 <= 0.0 {
+                continue;
+            }
 
             let transform_with_cs_offset = item.0 + spatial_data.transform - cs_offset;
             let instance_input = Self::create_instance_struct(

--- a/renderer/src/mesh/mod.rs
+++ b/renderer/src/mesh/mod.rs
@@ -10,6 +10,7 @@ pub mod positioned_mesh;
 pub struct InstanceBuffer<T: Pod> {
     pub buffer: Option<Buffer>,
     pub length: usize,
+    max_length: usize,
     _phantom_data: PhantomData<T>,
 }
 
@@ -18,6 +19,7 @@ impl<T: Pod> Default for InstanceBuffer<T> {
         InstanceBuffer {
             buffer: None,
             length: 0,
+            max_length: 0,
             _phantom_data: Default::default(),
         }
     }
@@ -25,10 +27,17 @@ impl<T: Pod> Default for InstanceBuffer<T> {
 
 impl<T: Pod> InstanceBuffer<T> {
     pub fn update(&mut self, label: &'static str, device: &Device, queue: &Queue, data: &Vec<T>) {
-        if data.len() <= self.length
+        // don't recreate the buffer if its max length doesn't grow
+        // TODO benchmark create_buffer_init vs write_buffer vs write_buffer_with
+        let data_len = data.len();
+        if data_len <= self.max_length
             && let Some(buffer) = self.buffer.as_ref()
         {
             queue.write_buffer(buffer, 0, bytemuck::cast_slice(data.as_slice()));
+            // FIXME write_buffer_with doesn't work as expected, why?
+            // if let Some(mut buf_view) = queue.write_buffer_with(buffer, 0, data_size) {
+            //     buf_view.copy_from_slice(data);
+            // }
         } else {
             self.buffer = Some(
                 device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
@@ -39,5 +48,6 @@ impl<T: Pod> InstanceBuffer<T> {
             );
         }
         self.length = data.len();
+        self.max_length = self.max_length.max(self.length);
     }
 }

--- a/renderer/src/mesh/positioned_mesh.rs
+++ b/renderer/src/mesh/positioned_mesh.rs
@@ -12,7 +12,6 @@ pub struct PositionedMesh<T: MeshInstanceInput> {
     mesh: Mesh,
     instance_buffer: InstanceBuffer<T>,
     attrs: Vec<T>,
-    instance_positions_and_alpha: Vec<(Vector3<f64>, f32)>, // TODO Proper structure with bound
     cs_offset: Vector3<f64>,
     double_style: bool,
     spatial_rx: Receiver<SpatialData>,
@@ -22,13 +21,11 @@ pub struct PositionedMesh<T: MeshInstanceInput> {
 impl Mesh {
     pub fn to_positioned<T: MeshInstanceInput>(
         self,
-        instance_positions: Option<Vec<Vector3<f64>>>,
         spatial_rx: tokio::sync::broadcast::Receiver<SpatialData>,
         double_style: bool,
     ) -> PositionedMesh<T> {
         PositionedMesh::new(
             self,
-            instance_positions,
             spatial_rx,
             double_style,
         )
@@ -38,20 +35,13 @@ impl Mesh {
 impl<T: MeshInstanceInput> PositionedMesh<T> {
     pub fn new(
         mesh: Mesh,
-        instance_positions: Option<Vec<Vector3<f64>>>,
         spatial_rx: tokio::sync::broadcast::Receiver<SpatialData>,
         double_style: bool,
     ) -> Self {
-        let instance_positions_and_alpha = instance_positions
-            .unwrap_or(vec![Vector3::new(0.0, 0.0, 0.0)])
-            .iter()
-            .map(|v| (*v, 1.0))
-            .collect();
         Self {
             mesh,
             instance_buffer: InstanceBuffer::default(),
             attrs: vec![],
-            instance_positions_and_alpha,
             cs_offset: Vector3::new(0.0, 0.0, 0.0),
             double_style,
             spatial_rx,
@@ -73,7 +63,7 @@ impl<T: MeshInstanceInput> PositionedMesh<T> {
             T::fill_attrs(
                 &mut self.attrs,
                 &self.cs_offset,
-                &self.instance_positions_and_alpha,
+                &vec![(Vector3::new(0.0, 0.0, 0.0), 1.0)],
                 &self.original_spatial_data,
                 self.double_style,
             );

--- a/renderer/src/mesh_layers/general_mesh_layer.rs
+++ b/renderer/src/mesh_layers/general_mesh_layer.rs
@@ -5,7 +5,6 @@ use crate::mesh_layers::render_data_holder::RenderDataHolder;
 use crate::mesh_layers::BaseMeshLayer;
 use crate::modifier::render_modifier::SpatialData;
 use crate::pipelines::RenderPipeline;
-use cgmath::Vector3;
 use wgpu::RenderPass;
 
 pub struct GeneralMeshLayer<P: RenderPipeline> {
@@ -25,13 +24,11 @@ impl<P: RenderPipeline> GeneralMeshLayer<P> {
     pub fn add(
         &mut self,
         key: String,
-        instance_positions: Option<Vec<Vector3<f64>>>,
         spatial_rx: tokio::sync::broadcast::Receiver<SpatialData>,
         double_style: bool,
         mesh: Mesh,
     ) {
         let mesh = P::create_positioned_mesh(
-            instance_positions,
             spatial_rx,
             double_style,
             mesh,

--- a/renderer/src/pipelines/mod.rs
+++ b/renderer/src/pipelines/mod.rs
@@ -1,10 +1,9 @@
-use crate::mesh::mesh::Mesh;
-use crate::modifier::render_modifier::SpatialData;
-use crate::mesh::positioned_mesh::PositionedMesh;
 use crate::global_context::GlobalContext;
-use cgmath::Vector3;
-use wgpu::{ColorTargetState, DepthStencilState, Device, Label, MultisampleState, PipelineCompilationOptions, PipelineLayout, PrimitiveState, RenderPass, ShaderModule, VertexBufferLayout};
+use crate::mesh::mesh::Mesh;
 use crate::mesh::mesh_instance_input::MeshInstanceInput;
+use crate::mesh::positioned_mesh::PositionedMesh;
+use crate::modifier::render_modifier::SpatialData;
+use wgpu::{ColorTargetState, DepthStencilState, Device, Label, MultisampleState, PipelineCompilationOptions, PipelineLayout, PrimitiveState, RenderPass, ShaderModule, VertexBufferLayout};
 
 pub mod mesh_pipeline;
 pub mod shape_pipeline;
@@ -13,11 +12,10 @@ pub mod text_pipeline;
 pub trait RenderPipeline {
     type InstanceInputType: MeshInstanceInput;
 
-    fn create_positioned_mesh(instance_positions: Option<Vec<Vector3<f64>>>,
-                              spatial_rx: tokio::sync::broadcast::Receiver<SpatialData>,
+    fn create_positioned_mesh(spatial_rx: tokio::sync::broadcast::Receiver<SpatialData>,
                               double_style: bool,
                               mesh: Mesh) -> PositionedMesh<Self::InstanceInputType> {
-        mesh.to_positioned::<Self::InstanceInputType>(instance_positions, spatial_rx, double_style)
+        mesh.to_positioned::<Self::InstanceInputType>(spatial_rx, double_style)
     }
 
     fn render(&mut self, render_pass: &mut RenderPass, global_context: &GlobalContext);


### PR DESCRIPTION
- Don't push fully transparent items to InstanceBuffer
- Don't recreate inner Buffer if the actual size doesn't grow