### PR TITLE
Fixes FPS drop when zoom in/out fast

### DIFF
--- a/renderer/src/canvas_api.rs
+++ b/renderer/src/canvas_api.rs
@@ -1,4 +1,4 @@
-use crate::draw_commands::mesh2d_draw_command::Mesh2dDrawCommand;
+use crate::draw_commands::mesh2d_draw_command::{Mesh2dCommandBatch, Mesh2dDrawCommand};
 use crate::draw_commands::mesh3d_draw_command::Mesh3dDrawCommand;
 use crate::draw_commands::text_draw_command::TextDrawCommand;
 use crate::draw_commands::{DrawCommand, DrawCommands, GeometryType, MeshVertex, PolylineOptions};
@@ -23,7 +23,7 @@ use std::mem;
 pub struct MeshInfo {
     pub instance_positions: Option<Vec<Vector3<f64>>>,
     pub with_collision: bool,
-    pub instance_key: String
+    pub instance_key: String,
 }
 
 pub struct CanvasApi {
@@ -105,9 +105,14 @@ impl CanvasApi {
             let mesh_info = MeshInfo {
                 instance_positions: None,
                 with_collision: false,
-                instance_key: "".to_string()
+                instance_key: "".to_string(),
             };
-            self.mesh2d_with_positions(mesh, flatten_ranges, mesh_info, false);
+            let batch = Mesh2dCommandBatch {
+                mesh,
+                layers_indices: flatten_ranges,
+                mesh_info,
+            };
+            self.mesh2d_with_positions(vec![batch], false);
         }
     }
 
@@ -115,15 +120,21 @@ impl CanvasApi {
         if self.mesh_info_cache.is_empty() {
             return;
         }
-        let data: Vec<_> = self
+        let batches = self
             .mesh_info_cache
             .iter()
             .map(|(_, (mesh, positions))| (mesh.clone(), positions.clone()))
+            .map(|(mesh, mesh_info)| {
+                let styled_range = StyledRange(0..mesh.indices.len(), StyledRangeInfo(0, ""));
+                Mesh2dCommandBatch {
+                    mesh,
+                    layers_indices: vec![styled_range],
+                    mesh_info,
+                }
+            })
             .collect();
-        for (mesh, mesh_info) in data {
-            let styled_range = StyledRange(0..mesh.indices.len(), StyledRangeInfo(0, ""));
-            self.mesh2d_with_positions(mesh, vec![styled_range], mesh_info, true);
-        }
+
+        self.mesh2d_with_positions(batches, true);
     }
 
     fn prepare_text_command(&mut self) {
@@ -135,17 +146,9 @@ impl CanvasApi {
         }));
     }
 
-    fn mesh2d_with_positions(
-        &mut self,
-        mesh: VertexBuffers<ShapeVertex, u32>,
-        layers_indices: Vec<StyledRange>,
-        mesh_info: MeshInfo,
-        is_screen: bool,
-    ) {
+    fn mesh2d_with_positions(&mut self, batches: Vec<Mesh2dCommandBatch>, is_screen: bool) {
         self.draw_commands.push(Box::new(Mesh2dDrawCommand {
-            mesh,
-            layers_indices,
-            mesh_info,
+            batches,
             is_screen,
             feature_layer_tag: self.feature_layer_tag.clone(),
         }));
@@ -248,10 +251,15 @@ impl CanvasApi {
             .indices_by_layers
             .entry(data.index_layer_level)
             .or_insert(Vec::new());
-        if let Some(last) = ranges.last_mut() && last.0.end == initial_index {
+        if let Some(last) = ranges.last_mut()
+            && last.0.end == initial_index
+        {
             last.0.end = last_index;
         } else {
-            ranges.push(StyledRange(initial_index..last_index, data.styled_range_info));
+            ranges.push(StyledRange(
+                initial_index..last_index,
+                data.styled_range_info,
+            ));
         }
     }
 
@@ -259,7 +267,10 @@ impl CanvasApi {
         self.mesh_info_cache
             .entry(data.icon.0)
             .and_modify(|(_, mesh_info)| {
-                mesh_info.instance_positions.get_or_insert_default().push(data.position);
+                mesh_info
+                    .instance_positions
+                    .get_or_insert_default()
+                    .push(data.position);
                 mesh_info.with_collision = data.with_collision
             })
             .or_insert_with(|| {
@@ -270,7 +281,7 @@ impl CanvasApi {
                     MeshInfo {
                         instance_positions: Some(vec![data.position]),
                         with_collision: data.with_collision,
-                        instance_key: data.icon.0.to_string()
+                        instance_key: data.icon.0.to_string(),
                     },
                 )
             });

--- a/renderer/src/draw_commands/mesh2d_draw_command.rs
+++ b/renderer/src/draw_commands/mesh2d_draw_command.rs
@@ -9,10 +9,15 @@ use lyon::tessellation::VertexBuffers;
 use std::mem;
 
 #[derive(Clone)]
-pub(crate) struct Mesh2dDrawCommand {
+pub(crate) struct Mesh2dCommandBatch {
     pub mesh: VertexBuffers<ShapeVertex, u32>,
     pub layers_indices: Vec<StyledRange>,
     pub mesh_info: MeshInfo,
+}
+
+#[derive(Clone)]
+pub(crate) struct Mesh2dDrawCommand {
+    pub batches: Vec<Mesh2dCommandBatch>,
     pub is_screen: bool,
     pub feature_layer_tag: Option<String>,
 }
@@ -32,27 +37,29 @@ impl DrawCommand for Mesh2dDrawCommand {
             .as_ref()
             .and_then(|tag| layers.feature_layers(tag))
         {
-            let mesh =
-                Mesh::create_layered(&device, &self.mesh, mem::take(&mut self.layers_indices));
-            feature_layer.add(
-                key,
-                spatial_rx,
-                !self.is_screen,
-                mesh,
-            );
+            if let Some(first_batch) = self.batches.first_mut() {
+                let mesh = Mesh::create_layered(
+                    &device,
+                    &first_batch.mesh,
+                    mem::take(&mut first_batch.layers_indices),
+                );
+                feature_layer.add(key.clone(), spatial_rx, !self.is_screen, mesh);
+            }
         } else if self.is_screen {
             layers
                 .screen_shape_layer
                 .submit(key.as_str(), spatial_data, global_context, self);
         } else {
-            let mesh =
-                Mesh::create_layered(&device, &self.mesh, mem::take(&mut self.layers_indices));
-            layers.shape_layer.add(
-                key,
-                spatial_rx,
-                !self.is_screen,
-                mesh,
-            );
+            if let Some(first_batch) = self.batches.first_mut() {
+                let mesh = Mesh::create_layered(
+                    &device,
+                    &first_batch.mesh,
+                    mem::take(&mut first_batch.layers_indices),
+                );
+                layers
+                    .shape_layer
+                    .add(key, spatial_rx, !self.is_screen, mesh);
+            }
         };
     }
 }

--- a/renderer/src/lib.rs
+++ b/renderer/src/lib.rs
@@ -179,7 +179,8 @@ impl ShashlikRenderer {
     fn update(&mut self, view_proj_matrix: Matrix4<f64>, cs_offset: Vector3<f64>) {
         self.global_context.update(view_proj_matrix, cs_offset);
 
-        if let Ok(message) = self.renderer_rx.try_recv() {
+        // read all messages between renders
+        for message in self.renderer_rx.try_iter() {
             match message {
                 RendererMessage::Draw(mut draw_commands) => {
                     draw_commands.execute(&mut self.global_context, &mut self.layers);

--- a/renderer/src/mesh_layers/general_mesh_layer.rs
+++ b/renderer/src/mesh_layers/general_mesh_layer.rs
@@ -35,7 +35,7 @@ impl<P: RenderPipeline> GeneralMeshLayer<P> {
             double_style,
             mesh,
         );
-        self.render_data_holder.add(key, mesh);
+        self.render_data_holder.set(key, vec![mesh]);
     }
 }
 

--- a/renderer/src/mesh_layers/render_data_holder.rs
+++ b/renderer/src/mesh_layers/render_data_holder.rs
@@ -12,10 +12,10 @@ impl<T> RenderDataHolder<T> {
         }
     }
 
-    pub fn add(&mut self, key: String, data: T) {
-        self.holder.entry(key).or_default().push(data);
+    pub fn set(&mut self, key: String, data: Vec<T>) {
+        self.holder.insert(key, data);
     }
-
+    
     pub fn remove(&mut self, key: &str) {
         self.holder.remove(&key.to_string());
     }

--- a/renderer/src/mesh_layers/screen_shape_layer.rs
+++ b/renderer/src/mesh_layers/screen_shape_layer.rs
@@ -49,28 +49,35 @@ impl<P: RenderPipeline> ScreenShapeLayer<P> {
         command: &mut Mesh2dDrawCommand,
     ) {
         let device = global_context.device();
-        let instance_key = command.mesh_info.instance_key.to_string();
 
-        self.meshes.entry(instance_key.clone()).or_insert({
-            (
-                Mesh::create_layered(
-                    &device,
-                    &command.mesh,
-                    mem::take(&mut command.layers_indices),
-                ),
-                InstanceBuffer::default(),
-            )
+        let mut data = vec![];
+        command.batches.iter_mut().for_each(|batch| {
+            let instance_key = batch.mesh_info.instance_key.to_string();
+
+            self.meshes.entry(instance_key.clone()).or_insert({
+                (
+                    Mesh::create_layered(
+                        &device,
+                        &batch.mesh,
+                        mem::take(&mut batch.layers_indices),
+                    ),
+                    InstanceBuffer::default(),
+                )
+            });
+
+            let instance_positions =
+                mem::take(&mut batch.mesh_info.instance_positions).unwrap_or_default();
+
+            let batch_data: Vec<_> = instance_positions.into_iter().map(|item| {
+                (item + spatial_data.transform, 0.0f32, instance_key.clone())
+            }).collect();
+
+            data.extend(batch_data)
         });
 
-        let instance_positions =
-            mem::take(&mut command.mesh_info.instance_positions).unwrap_or_default();
-
-        instance_positions.into_iter().for_each(|item| {
-            let key = key.to_string();
-            let instance_key = instance_key.clone();
-            self.collision_task_controller.update_data(move |holder| {
-                holder.add(key, (item + spatial_data.transform, 0.0f32, instance_key.clone()));
-            });
+        let key = key.to_string();
+        self.collision_task_controller.update_data(move |holder| {
+            holder.set(key, data)
         });
     }
 }

--- a/renderer/src/mesh_layers/text_mesh_layer.rs
+++ b/renderer/src/mesh_layers/text_mesh_layer.rs
@@ -25,17 +25,17 @@ impl<P: RenderPipeline> TextMeshLayer<P> {
         }
     }
 
-    pub fn add(&mut self, key: String, text_data: Vec<TextData>, spatial_data: SpatialData) {
+    pub fn add(&mut self, key: String, mut text_data: Vec<TextData>, spatial_data: SpatialData) {
         self.text_renderer.update_data(move |holder| {
-            text_data.into_iter().for_each(|mut item| {
+            text_data.iter_mut().for_each(|item| {
                 item.alpha = 0.0;
                 item.positions = item
                     .positions
                     .iter()
                     .map(|pos| pos + spatial_data.transform.cast().unwrap())
                     .collect();
-                holder.add(key.clone(), item);
             });
+            holder.set(key.clone(), text_data)
         });
     }
 


### PR DESCRIPTION
1) Render data holder now uses the whole vector as a data, so mo mesh duplicates in there with the same key
2) Renderer's update iterate through all messages instead of msg per frame
3) Closes #36 