### PR TITLE
Optimize power of two scale calculation

### DIFF
--- a/renderer/src/shaders/mesh_shader.wgsl
+++ b/renderer/src/shaders/mesh_shader.wgsl
@@ -3,7 +3,8 @@
 struct CameraUniform {
     view_proj: mat4x4<f32>,
     inv_screen_size: vec2<f32>,
-    scale: f32
+    scale: f32,
+    p2_scale: f32
 };
 @group(0) @binding(0)
 var<uniform> camera: CameraUniform;

--- a/renderer/src/shaders/screen_mesh_shader.wgsl
+++ b/renderer/src/shaders/screen_mesh_shader.wgsl
@@ -1,7 +1,8 @@
 struct CameraUniform {
     view_proj: mat4x4<f32>,
     inv_screen_size: vec2<f32>,
-    scale: f32
+    scale: f32,
+    p2_scale: f32
 };
 
 

--- a/renderer/src/shaders/shape_shader.wgsl
+++ b/renderer/src/shaders/shape_shader.wgsl
@@ -4,7 +4,8 @@ const PARAMS_COUNT : i32 = 12;
 struct CameraUniform {
     view_proj: mat4x4<f32>,
     inv_screen_size: vec2<f32>,
-    scale: f32
+    scale: f32,
+    p2_scale: f32
 };
 
 struct StyleUniform {
@@ -106,11 +107,7 @@ fn vs_main_route(
     out.color_alpha = pos.color_alpha;
 
     if(!with_normal && camera_scale >= 0.0) {
-        var p2_scale = 1.0;
-        let p2 = u32(ceil(log2(camera_scale)));
-        if(p2 >= 1) {
-            p2_scale = f32(2 << (p2 - 1));
-        }
+        let p2_scale = camera.p2_scale;
 
         let i = model.instance_index;
         if(i % u32(p2_scale) != 0) {

--- a/renderer/src/view_projection.rs
+++ b/renderer/src/view_projection.rs
@@ -23,7 +23,8 @@ const FLIP_Y: Matrix4<f64> = Matrix4::new(
 pub(crate) struct ViewProjUniform {
     view_proj: [[f32; 4]; 4],
     inv_screen_size: [f32; 2],
-    scale: f32
+    scale: f32,
+    p2_scale: f32
 }
 
 #[derive(Clone)]
@@ -53,7 +54,8 @@ impl ViewProjection {
             uniform: ViewProjUniform {
                 view_proj: Matrix4::identity().into(),
                 inv_screen_size: [0.0, 0.0],
-                scale: 0.0
+                scale: 0.0,
+                p2_scale: 1.0
             },
             screen_size: (0.0, 0.0),
             cs_offset: Vector3::new(0.0, 0.0, 0.0),
@@ -72,6 +74,7 @@ impl ViewProjection {
             .unwrap()
             .into();
         self.uniform.scale = scale;
+        self.uniform.p2_scale = self.p2_scale(scale);
         self.cs_offset = cs_offset;
         self.inv_view_proj_matrix = view_proj_matrix.inverse_transform().unwrap();
         self.screen_size = (config.width as f64, config.height as f64);
@@ -83,7 +86,16 @@ impl ViewProjection {
         );
     }
 
-    pub fn screen_position(&self, world_position: &Vector3<f64>) -> Coord<f64> {
+    fn p2_scale(&mut self, scale: f32) -> f32 {
+        let p2 = scale.log2().ceil() as u32;
+        let mut p2_scale = 1u32;
+        if p2 >= 1 {
+            p2_scale = 2 << (p2 - 1);
+        }
+        p2_scale as f32
+    }
+
+pub fn screen_position(&self, world_position: &Vector3<f64>) -> Coord<f64> {
         let matrix: Matrix4<f32> = self.uniform.view_proj.into();
         let world_position = world_position - self.cs_offset;
         let pos = matrix.cast().unwrap() * Vector4::new(world_position.x, world_position.y, 0.0, 1.0);


### PR DESCRIPTION
Calculate it only once per frame on CPU, instead of every vertex on GPU