### PR TITLE
SSAO. Minor texture format fixes

### DIFF
--- a/renderer/src/mesh_layers/general_mesh_layer.rs
+++ b/renderer/src/mesh_layers/general_mesh_layer.rs
@@ -8,6 +8,7 @@ use crate::modifier::render_modifier::SpatialData;
 use crate::pipelines::RenderPipeline;
 use std::mem;
 use wgpu::{CommandEncoder, ComputePassDescriptor, RenderPass};
+use wgpu::TextureFormat::Rgba16Float;
 
 pub(crate) struct GeneralMeshLayer<P: RenderPipeline> {
     render_pipeline: P,
@@ -75,7 +76,6 @@ impl<P: RenderPipeline> GeneralMeshLayer<P> {
 
 impl<P: RenderPipeline> BaseMeshLayer for GeneralMeshLayer<P> {
     fn prepare(&mut self, global_context: &GlobalContext) {
-        let config = global_context.config();
         let descriptor = self.render_pipeline.prepare(global_context);
         let mut g_buffer_descriptor = descriptor.clone();
 
@@ -84,11 +84,11 @@ impl<P: RenderPipeline> BaseMeshLayer for GeneralMeshLayer<P> {
         g_buffer_descriptor.label = Some("g_buffer_pipeline");
         let fragment = g_buffer_descriptor.fragment.as_mut().unwrap();
         fragment.targets = vec![Some(wgpu::ColorTargetState {
-            format: config.format,
+            format: Rgba16Float,
             blend: None,
             write_mask: wgpu::ColorWrites::ALL,
         }), Some(wgpu::ColorTargetState {
-            format: config.format,
+            format: Rgba16Float,
             blend: None,
             write_mask: wgpu::ColorWrites::ALL,
         })];

--- a/renderer/src/pass_nodes/main_pass_node.rs
+++ b/renderer/src/pass_nodes/main_pass_node.rs
@@ -2,8 +2,8 @@ use crate::global_context::GlobalContext;
 use crate::mesh_layers::layers::Layers;
 use crate::mesh_layers::BaseMeshLayer;
 use crate::pass_nodes::PassNode;
-use crate::textures::{create_common_texture, create_depth_texture, SAMPLE_COUNT};
-use wgpu::{include_wgsl, BindGroup, CommandEncoder, ComputePassDescriptor, ComputePipeline, ComputePipelineDescriptor, StorageTextureAccess, TextureFormat, TextureView, TextureViewDimension};
+use crate::textures::{create_common_texture, create_depth_texture, create_simple_texture, TextureData, SAMPLE_COUNT};
+use wgpu::{include_wgsl, BindGroup, CommandEncoder, ComputePassDescriptor, ComputePipeline, ComputePipelineDescriptor, StorageTextureAccess, TextureFormat, TextureUsages, TextureView, TextureViewDimension};
 
 pub(crate) struct MainPassNode {
     msaa_texture_view: TextureView,
@@ -24,8 +24,24 @@ impl MainPassNode {
 
         let device = global_context.device();
 
-        let non_msaa_texture_view_positions = create_common_texture(size, 1, global_context);
-        let non_msaa_texture_view_normals = create_common_texture(size, 1, global_context);
+        let non_msaa_texture_view_positions = create_simple_texture(
+            TextureData {
+                sample_count: 1,
+                size,
+                usage: TextureUsages::RENDER_ATTACHMENT | TextureUsages::TEXTURE_BINDING,
+                format: TextureFormat::Rgba16Float,
+            },
+            global_context.device(),
+        );
+        let non_msaa_texture_view_normals = create_simple_texture(
+            TextureData {
+                sample_count: 1,
+                size,
+                usage: TextureUsages::RENDER_ATTACHMENT | TextureUsages::TEXTURE_BINDING,
+                format: TextureFormat::Rgba16Float,
+            },
+            global_context.device(),
+        );
 
         let ssao_bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
             entries: &[wgpu::BindGroupLayoutEntry {
@@ -142,8 +158,8 @@ impl PassNode for MainPassNode {
             ops: wgpu::Operations {
                 load: wgpu::LoadOp::Clear(wgpu::Color {
                     r: 0.0,
-                    g: 0.741,
-                    b: 0.961,
+                    g: 0.0,
+                    b: 0.0,
                     a: 1.0,
                 }),
                 store: wgpu::StoreOp::Store,
@@ -156,8 +172,8 @@ impl PassNode for MainPassNode {
             ops: wgpu::Operations {
                 load: wgpu::LoadOp::Clear(wgpu::Color {
                     r: 0.0,
-                    g: 0.741,
-                    b: 0.961,
+                    g: 0.0,
+                    b: 0.0, // TODO We may use 1.0 here to simulate z normal for ground
                     a: 1.0,
                 }),
                 store: wgpu::StoreOp::Store,

--- a/renderer/src/shaders/ssao.wgsl
+++ b/renderer/src/shaders/ssao.wgsl
@@ -7,11 +7,10 @@
 @compute @workgroup_size(8, 8, 1)
 fn compute_main(@builtin(global_invocation_id) id: vec3<u32>) {
     let pixel_coord = id.xy;
-    let center = vec2f(256.0);
-    let dist = distance(vec2f(pixel_coord), center);
-    let stripe = dist / 32.0 % 2.0;
     let normal = textureLoad(normals, pixel_coord, 0);
-    let pos = textureLoad(positions, pixel_coord, 0);
-    let color = select(normal.r * pos.r, normal.g * pos.g, stripe < 1.0);
-    textureStore(ssao_texture, pixel_coord, vec4f(color, 0.0, 0.0, 0.0));
+    if abs(normal.x) > 0.0 || abs(normal.y) > 0.0 || abs(normal.z) > 0.0 {
+        textureStore(ssao_texture, pixel_coord, vec4f(0.0, 0.0, 0.0, 0.0));
+    } else {
+        textureStore(ssao_texture, pixel_coord, vec4f(1.0, 0.0, 0.0, 0.0));
+    }
 }


### PR DESCRIPTION
Fixes texture formats for G-buffer. Now, it uses `Rgba16Float` to increase precision.