### PR TITLE
SSAO. Inverted View Projection matrix to uniforms

### DIFF
--- a/renderer/src/shaders/mesh_shader.wgsl
+++ b/renderer/src/shaders/mesh_shader.wgsl
@@ -4,6 +4,7 @@ struct CameraUniform {
     view: mat4x4<f32>,
     proj: mat4x4<f32>,
     view_proj: mat4x4<f32>,
+    view_proj_inv: mat4x4<f32>,
     view_tr_inv: mat4x4<f32>,
     inv_screen_size: vec2<f32>,
     scale: f32,

--- a/renderer/src/shaders/screen_mesh_shader.wgsl
+++ b/renderer/src/shaders/screen_mesh_shader.wgsl
@@ -2,6 +2,7 @@ struct CameraUniform {
     view: mat4x4<f32>,
     proj: mat4x4<f32>,
     view_proj: mat4x4<f32>,
+    view_proj_inv: mat4x4<f32>,
     view_tr_inv: mat4x4<f32>,
     inv_screen_size: vec2<f32>,
     scale: f32,

--- a/renderer/src/shaders/shape_culling.wgsl
+++ b/renderer/src/shaders/shape_culling.wgsl
@@ -2,6 +2,7 @@ struct CameraUniform {
     view: mat4x4<f32>,
     proj: mat4x4<f32>,
     view_proj: mat4x4<f32>,
+    view_proj_inv: mat4x4<f32>,
     view_tr_inv: mat4x4<f32>,
     inv_screen_size: vec2<f32>,
     scale: f32,

--- a/renderer/src/shaders/shape_shader.wgsl
+++ b/renderer/src/shaders/shape_shader.wgsl
@@ -5,6 +5,7 @@ struct CameraUniform {
     view: mat4x4<f32>,
     proj: mat4x4<f32>,
     view_proj: mat4x4<f32>,
+    view_proj_inv: mat4x4<f32>,
     view_tr_inv: mat4x4<f32>,
     inv_screen_size: vec2<f32>,
     scale: f32,

--- a/renderer/src/shaders/ssao.wgsl
+++ b/renderer/src/shaders/ssao.wgsl
@@ -10,6 +10,7 @@ struct CameraUniform {
     view: mat4x4<f32>,
     proj: mat4x4<f32>,
     view_proj: mat4x4<f32>,
+    view_proj_inv: mat4x4<f32>,
     view_tr_inv: mat4x4<f32>,
     inv_screen_size: vec2<f32>,
     scale: f32,

--- a/renderer/src/view_projection.rs
+++ b/renderer/src/view_projection.rs
@@ -24,6 +24,7 @@ pub(crate) struct ViewProjUniform {
     view: [[f32; 4]; 4],
     proj: [[f32; 4]; 4],
     view_proj: [[f32; 4]; 4],
+    view_proj_inv: [[f32; 4]; 4],
     view_tr_inv: [[f32; 4]; 4],
     inv_screen_size: [f32; 2],
     scale: f32,
@@ -58,6 +59,7 @@ impl ViewProjection {
                 view: Matrix4::identity().into(),
                 proj: Matrix4::identity().into(),
                 view_proj: Matrix4::identity().into(),
+                view_proj_inv: Matrix4::identity().into(),
                 view_tr_inv: Matrix4::identity().into(),
                 inv_screen_size: [0.0, 0.0],
                 scale: 0.0,
@@ -85,7 +87,13 @@ impl ViewProjection {
             .cast()
             .unwrap()
             .into();
-        self.uniform.view_proj = (FLIP_Y * OPENGL_TO_WGPU_MATRIX * view_proj_matrix)
+        let view_proj = FLIP_Y * OPENGL_TO_WGPU_MATRIX * view_proj_matrix;
+        self.uniform.view_proj = view_proj
+            .cast()
+            .unwrap()
+            .into();
+        let view_proj_inv = view_proj.invert().unwrap();
+        self.uniform.view_proj_inv = view_proj_inv
             .cast()
             .unwrap()
             .into();


### PR DESCRIPTION
Added the inverse view projection matrix to construct world positions from clip space in the SSAO shader.