### PR TITLE
Fix a broken rendering during route creating

### DIFF
--- a/map/src/lib.rs
+++ b/map/src/lib.rs
@@ -162,11 +162,6 @@ impl<T: TilesProvider> ShashlikMap<T> {
         map.set_lon_lat_bearing(initial_coord.x, initial_coord.y, Some(0f32));
         map.load_styles();
 
-        // FIXME, the first route rendering can take a lot of time...
-        if cfg!(target_os = "linux") {
-            map.create_route_to((initial_coord.x, initial_coord.y), RouteCosting::Auto);
-        }
-
         Self::start_sgnss_if_available(map_event_sender);
 
         Ok(map)

--- a/map/src/route/route_controller.rs
+++ b/map/src/route/route_controller.rs
@@ -13,12 +13,14 @@ use valhalla_client::route::{DirectionsType, Location, Manifest};
 
 pub struct RouteController {
     current_lon_lat: Option<(f64, f64)>,
+    valhalla: Arc<Valhalla>
 }
 
 impl RouteController {
     pub fn new() -> RouteController {
         RouteController {
             current_lon_lat: None,
+            valhalla: Arc::new(Valhalla::default())
         }
     }
     pub fn set_current_lon_lat(&mut self, lon_lat: (f64, f64)) {
@@ -33,9 +35,8 @@ impl RouteController {
         api: Arc<RendererApi>,
     ) {
         if let Some((lon, lat)) = self.current_lon_lat {
+            let valhalla = Arc::clone(&self.valhalla);
             spawn(move || {
-                let valhalla = Valhalla::default();
-
                 let source_loc = Location::new(lon as f32, lat as f32);
                 let destination_loc = Location::new(to_lon_lat.0 as f32, to_lon_lat.1 as f32);
                 let costing = match route_costing {


### PR DESCRIPTION
Valhalla/Tokio init affects somehow event loop for Slint and rendering might get broken for half of second.
Fix: moving Valhalla initialization to the app launch