### PR TITLE
SSAO improvements

### DIFF
--- a/map/src/camera.rs
+++ b/map/src/camera.rs
@@ -1,4 +1,9 @@
-use glam::{dvec3, DMat2, DMat3, DMat4, DVec2, DVec3};
+use glam::dvec3;
+use glam::DMat2;
+use glam::DMat3;
+use glam::DMat4;
+use glam::DVec2;
+use glam::DVec3;
 use std::f64::consts::PI;
 use renderer::LIGHT_POS;
 

--- a/renderer/src/global_context.rs
+++ b/renderer/src/global_context.rs
@@ -34,9 +34,9 @@ impl GlobalContext {
         let ssao_texture = create_simple_texture(
             TextureData {
                 sample_count: 1,
-                size: (canvas.config().width / 2, canvas.config().height / 2),
+                size: (canvas.config().width, canvas.config().height),
                 usage: TextureUsages::TEXTURE_BINDING | TextureUsages::STORAGE_BINDING,
-                format: TextureFormat::R32Float,
+                format: TextureFormat::Rgba16Float,
             },
             device,
         );

--- a/renderer/src/mesh_layers/layers.rs
+++ b/renderer/src/mesh_layers/layers.rs
@@ -57,7 +57,7 @@ impl Layers {
             }), false, true),
             post_process_layer: OrthoMeshLayer::new(ScreenMeshPipeline::new(global_context, TextureInfo {
                 use_texture: true,
-                filterable: false,
+                filterable: true,
                 fs_shader: "fs_main_tex_storage",
             }), true, false),
         }

--- a/renderer/src/pass_nodes/main_pass_node.rs
+++ b/renderer/src/pass_nodes/main_pass_node.rs
@@ -28,8 +28,8 @@ impl MainPassNode {
         );
 
         let non_msaa_size = (
-            global_context.config().width / 2,
-            global_context.config().height / 2,
+            global_context.config().width,
+            global_context.config().height,
         );
 
         let device = global_context.device();
@@ -63,7 +63,7 @@ impl MainPassNode {
                 visibility: wgpu::ShaderStages::COMPUTE,
                 ty: wgpu::BindingType::StorageTexture {
                     access: StorageTextureAccess::WriteOnly,
-                    format: TextureFormat::R32Float,
+                    format: TextureFormat::Rgba16Float,
                     view_dimension: TextureViewDimension::D2,
                 },
                 count: None,
@@ -269,7 +269,8 @@ impl PassNode for MainPassNode {
                 layers.render(&mut render_pass, global_context);
             }
 
-            encoder.clear_texture(global_context.ssao_texture.texture(), &ImageSubresourceRange::default());
+            let ssao_texture = global_context.ssao_texture.texture();
+            encoder.clear_texture(ssao_texture, &ImageSubresourceRange::default());
             let mut compute_pass = encoder.begin_compute_pass(&ComputePassDescriptor {
                 label: Some("SSAO Compute Pass"),
                 timestamp_writes: None,
@@ -277,9 +278,8 @@ impl PassNode for MainPassNode {
             compute_pass.set_pipeline(&self.ssao_compute_pipeline);
             compute_pass.set_bind_group(0, &self.ssao_bind_group, &[]);
             compute_pass.set_bind_group(1, &self.camera_ssao_bind_group, &[]);
-
-            let wg_x = (global_context.view_projection.screen_size.0 * 0.5 / 8.0).ceil() as u32;
-            let wg_y = (global_context.view_projection.screen_size.1 * 0.5 / 8.0).ceil() as u32;
+            let wg_x = (ssao_texture.size().width as f32 / 8.0).ceil() as u32;
+            let wg_y = (ssao_texture.size().height as f32 / 8.0).ceil() as u32;
             compute_pass.dispatch_workgroups(wg_x, wg_y, 1);
         }
 

--- a/renderer/src/pass_nodes/main_pass_node.rs
+++ b/renderer/src/pass_nodes/main_pass_node.rs
@@ -62,7 +62,7 @@ impl MainPassNode {
                 binding: 0,
                 visibility: wgpu::ShaderStages::COMPUTE,
                 ty: wgpu::BindingType::StorageTexture {
-                    access: StorageTextureAccess::ReadWrite,
+                    access: StorageTextureAccess::WriteOnly,
                     format: TextureFormat::R32Float,
                     view_dimension: TextureViewDimension::D2,
                 },

--- a/renderer/src/pipelines/screen_mesh_pipeline.rs
+++ b/renderer/src/pipelines/screen_mesh_pipeline.rs
@@ -51,7 +51,7 @@ impl ScreenMeshPipeline {
                         visibility: wgpu::ShaderStages::FRAGMENT,
                         // This should match the filterable field of the
                         // corresponding Texture entry above.
-                        ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::NonFiltering),
+                        ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
                         count: None,
                     },
                     wgpu::BindGroupLayoutEntry {
@@ -148,7 +148,11 @@ impl WithTexture for ScreenMeshPipeline {
         global_context: &GlobalContext,
     ) -> BindGroup {
         let device = global_context.device();
-        let diffuse_sampler = device.create_sampler(&Default::default());
+        let diffuse_sampler = device.create_sampler(&SamplerDescriptor {
+            mag_filter: wgpu::FilterMode::Linear,
+            min_filter: wgpu::FilterMode::Linear,
+            ..Default::default()
+        });
         let sampler_compare = device.create_sampler(&SamplerDescriptor {
             mag_filter: wgpu::FilterMode::Linear,
             min_filter: wgpu::FilterMode::Linear,
@@ -160,7 +164,7 @@ impl WithTexture for ScreenMeshPipeline {
                 sample_count: 1,
                 size: (1, 1),
                 usage: TextureUsages::TEXTURE_BINDING,
-                format: TextureFormat::R32Float,
+                format: TextureFormat::Rgba16Float,
             },
             device,
         );

--- a/renderer/src/shaders/mesh_shader.wgsl
+++ b/renderer/src/shaders/mesh_shader.wgsl
@@ -82,7 +82,7 @@ var s_compare: sampler_comparison;
 // Fragment shader
 @fragment
 fn fs_main(in: VertexOutput) -> @location(0) vec4<f32>  {
-    let gradient_koef = 0.5 + min(1.0, tanh(2.0 * in.world_position.z)) / 2.0;
+    let gradient_koef = 0.5 + min(1.0, tanh(0.5 + 2.0 * in.world_position.z)) / 2.0;
     let diffuse_color = max(dot(in.world_normal, light_dir), 0.0);
 
     var shadow = 0.0;

--- a/renderer/src/shaders/screen_mesh_shader.wgsl
+++ b/renderer/src/shaders/screen_mesh_shader.wgsl
@@ -89,12 +89,15 @@ fn fs_main_textured(in: VertexOutput) -> @location(0) vec4<f32> {
 
 @fragment
 fn fs_main_tex_storage(in: VertexOutput) -> @location(0) vec4<f32> {
-    let f = fract(floor(in.clip_position.xy * 0.5) - 0.5);
-
-    let values = textureGather(0, t_diffuse, s_diffuse, in.uv);
-    let top = mix(values.w, values.z, f.x);
-    let bottom = mix(values.x, values.y, f.x);
-    return vec4f(0.0, 0.0, 0.0, mix(top, bottom, f.y));
+    var result = 0.0;
+    let texelSize = 1.0 / vec2f(textureDimensions(t_diffuse));
+    for (var y = -3; y < 3; y++) {
+      for (var x = -3; x < 3; x++) {
+        let offset = in.uv + vec2f(f32(x), f32(y)) * texelSize;
+        result += textureSample(t_diffuse, s_diffuse, offset).r;
+      }
+    }
+    return vec4f(0.0, 0.0, 0.0, result / 36.0);
 }
 
 @fragment

--- a/renderer/src/shaders/ssao.wgsl
+++ b/renderer/src/shaders/ssao.wgsl
@@ -1,7 +1,7 @@
 import super::common::CameraUniform;
 import super::common::frag_pos_from_ray;
 
-@group(0) @binding(0) var ssao_texture: texture_storage_2d<r32float, write>;
+@group(0) @binding(0) var ssao_texture: texture_storage_2d<rgba16float, write>;
 
 @group(0) @binding(1) var normals: texture_2d<f32>;
 
@@ -22,32 +22,94 @@ fn compute_main(@builtin(global_invocation_id) id: vec3<u32>) {
     compute_ssao(pixel_coord, vec2f(ssao_size));
 }
 
-const radius: f32 = 0.2;
+const radius: f32 = 0.12;
 
-const samples: i32 = 10;
+const samples: i32 = 16;
 const kernel = array<vec3f, samples>(
-        vec3f(0.007037f, 0.539844f, -0.006580f),
-        vec3f(-0.133574f, -0.183743f, -0.846069f),
-        vec3f(-0.996510f, -0.615594f, 0.335935f),
-        vec3f(0.608887f, 0.337568f, -0.905423f),
-        vec3f(-0.845961f, 0.952486f, 0.962096f),
-        vec3f(-0.215490f, 0.248707f, -0.296498f),
-        vec3f(-0.489900f, 0.828894f, 0.676423f),
-        vec3f(0.945187f, 0.577881f, 0.233983f),
-        vec3f(-0.004757f, 0.815544f, -0.399097f),
-        vec3f(0.083159f, 0.472272f, 0.397275f)
+        vec3f(0.325931f, 0.331029f, 0.967709f),
+                vec3f(-0.087517f, -0.739311f, 0.030716f),
+                vec3f(0.504828f, 0.076937f, 0.227086f),
+                vec3f(-0.639056f, 0.310719f, 0.751524f),
+                vec3f(0.813696f, -0.674305f, 0.371703f),
+                vec3f(-0.921673f, -0.361186f, 0.892556f),
+                vec3f(-0.348158f, -0.513016f, 0.116095f),
+                vec3f(-0.009523f, -0.776991f, 0.792030f),
+                vec3f(0.212048f, -0.997931f, 0.000883f),
+                vec3f(0.153850f, 0.098625f, 0.196745f),
+                vec3f(-0.437783f, -0.308788f, 0.571267f),
+                vec3f(-0.847969f, -0.691004f, 0.139359f),
+                vec3f(0.279546f, -0.846539f, 0.317021f),
+                vec3f(0.014279f, 0.465680f, 0.938725f),
+                vec3f(-0.996073f, -0.600005f, 0.903233f),
+                vec3f(-0.064112f, -0.017207f, 0.395765f)
     );
 
-const noise_size: u32 = 2;
-const noise: array<vec3f, 8> = array<vec3f, 8>(
-        vec3f(0.607190f, -0.312189f, 0.818114f),
-        vec3f(0.156606f, -0.817238f, -0.217971f),
-        vec3f(-0.417291f, 0.065830f, -0.060644f),
-        vec3f(-0.732652f, -0.385451f, -0.551573f),
-        vec3f(0.585352f, -0.433822f, 0.307726f),
-        vec3f(0.635344f, 0.910413f, 0.477567f),
-        vec3f(-0.147777f, -0.358135f, -0.246600f),
-        vec3f(0.545311f, -0.709271f, -0.237195f)
+const noise_size: u32 = 8;
+const noise: array<vec3f, 64> = array<vec3f, 64>(
+        vec3f(0.498019f, -0.138723f, -0.719221f),
+                vec3f(-0.715574f, -0.550533f, 0.907703f),
+                vec3f(-0.292364f, -0.793055f, -0.087154f),
+                vec3f(0.839407f, 0.397618f, 0.637048f),
+                vec3f(0.563101f, -0.412131f, 0.134669f),
+                vec3f(-0.384664f, 0.779189f, -0.012993f),
+                vec3f(-0.106794f, -0.008540f, 0.107459f),
+                vec3f(0.043171f, 0.337181f, 0.250799f),
+                vec3f(0.194708f, -0.198697f, -0.550653f),
+                vec3f(0.810833f, -0.350475f, -0.875343f),
+                vec3f(-0.536346f, 0.644168f, 0.690995f),
+                vec3f(-0.801291f, -0.420952f, 0.550404f),
+                vec3f(-0.835689f, 0.374756f, 0.895130f),
+                vec3f(0.399514f, 0.756081f, 0.290326f),
+                vec3f(-0.017290f, -0.261606f, -0.852619f),
+                vec3f(0.028135f, -0.004988f, -0.145844f),
+                vec3f(0.925236f, 0.670672f, -0.595862f),
+                vec3f(-0.181731f, -0.235191f, 0.022157f),
+                vec3f(0.634719f, -0.678178f, -0.466862f),
+                vec3f(-0.166032f, -0.959113f, 0.912086f),
+                vec3f(0.294799f, 0.694731f, 0.968655f),
+                vec3f(-0.756248f, -0.129110f, -0.775143f),
+                vec3f(-0.145545f, -0.614639f, -0.328204f),
+                vec3f(0.521186f, -0.620808f, -0.675555f),
+                vec3f(0.454221f, 0.385564f, -0.770635f),
+                vec3f(0.377082f, -0.186898f, -0.021890f),
+                vec3f(-0.227836f, 0.043232f, 0.384662f),
+                vec3f(0.679012f, 0.346184f, 0.304211f),
+                vec3f(-0.410387f, -0.579056f, -0.524389f),
+                vec3f(0.809811f, 0.373289f, -0.852437f),
+                vec3f(0.362048f, 0.758220f, 0.796465f),
+                vec3f(0.723425f, 0.879283f, -0.528698f),
+                vec3f(0.897106f, 0.209561f, -0.966730f),
+                vec3f(0.181903f, 0.285992f, -0.649164f),
+                vec3f(-0.350314f, -0.119617f, 0.170969f),
+                vec3f(0.100983f, -0.231861f, -0.752096f),
+                vec3f(0.544564f, -0.474695f, -0.134790f),
+                vec3f(-0.201528f, 0.143371f, 0.237068f),
+                vec3f(0.264013f, -0.043871f, 0.426481f),
+                vec3f(0.190253f, -0.261845f, 0.534904f),
+                vec3f(0.562281f, 0.998846f, -0.138655f),
+                vec3f(-0.874622f, 0.502285f, -0.407575f),
+                vec3f(0.725221f, 0.412502f, -0.692343f),
+                vec3f(0.842110f, -0.461721f, 0.175263f),
+                vec3f(-0.464554f, -0.526278f, -0.224698f),
+                vec3f(0.401873f, -0.349921f, -0.918575f),
+                vec3f(0.072981f, 0.877680f, -0.029451f),
+                vec3f(0.101450f, -0.776793f, 0.081240f),
+                vec3f(-0.129580f, 0.219344f, 0.316880f),
+                vec3f(-0.897223f, 0.997737f, 0.664348f),
+                vec3f(-0.589849f, -0.544437f, -0.236715f),
+                vec3f(-0.728900f, 0.750518f, -0.507394f),
+                vec3f(-0.247685f, -0.076829f, -0.503319f),
+                vec3f(-0.891851f, -0.052599f, -0.822399f),
+                vec3f(-0.465307f, -0.533684f, 0.515048f),
+                vec3f(-0.571649f, 0.130919f, -0.340096f),
+                vec3f(-0.381016f, -0.895360f, -0.876841f),
+                vec3f(0.993966f, 0.397833f, 0.103650f),
+                vec3f(-0.355190f, -0.424137f, 0.409542f),
+                vec3f(0.193815f, -0.830927f, -0.828270f),
+                vec3f(-0.068930f, 0.543515f, -0.726717f),
+                vec3f(-0.014475f, 0.347422f, -0.839274f),
+                vec3f(-0.064014f, -0.210524f, 0.213194f),
+                vec3f(-0.016824f, 0.526055f, 0.373054f)
     );
 
 fn compute_ssao(pixel_coord: vec2<u32>, ssao_size: vec2f) {
@@ -59,7 +121,7 @@ fn compute_ssao(pixel_coord: vec2<u32>, ssao_size: vec2f) {
 
     var fragPos = vec3f(0.0, 0.0, 0.0);
     if(loadedNormal.x == 0.0 && loadedNormal.y == 0.0 && loadedNormal.z == 0.0) {
-        let uv_coord = (vec2f(2 * pixel_coord.xy) * camera.inv_screen_size) * 2.0 - 1.0;
+        let uv_coord = (vec2f(pixel_coord.xy) * camera.inv_screen_size) * 2.0 - 1.0;
         fragPos = frag_pos_from_ray(camera, uv_coord);
         fragPos = (camera.view * vec4f(fragPos, 1.0)).xyz;
         normal = normalize((camera.view_tr_inv * vec4f(0.0, 0.0, 1.0, 1.0)).xyz);
@@ -78,7 +140,6 @@ fn compute_ssao(pixel_coord: vec2<u32>, ssao_size: vec2f) {
     var occlusion = 0.0;
     for (var i = 0; i < samples; i++) {
         var kl = kernel[i];
-        kl.z = kl.z * 0.5 + 0.5;
         let dist_scale = f32(i) / f32(samples);
         let samplePos = fragPos + (TBN * (kl * lerp(0.1, 1.0, dist_scale * dist_scale))) * radius;
 
@@ -96,7 +157,7 @@ fn compute_ssao(pixel_coord: vec2<u32>, ssao_size: vec2f) {
 
         let rangeCheck = smoothstep(0.1, 1.0, (radius) / abs(fragPos.z - sampleDepth));
 
-        occlusion += select(0.0, 1.0, sampleDepth > samplePos.z + 0.1) * rangeCheck;
+        occlusion += select(0.0, 1.0, sampleDepth >= samplePos.z + 0.05) * rangeCheck;
     }
 
     if(occlusion > 0.0) {

--- a/renderer/src/shaders/ssao.wgsl
+++ b/renderer/src/shaders/ssao.wgsl
@@ -1,7 +1,7 @@
 import super::common::CameraUniform;
 import super::common::frag_pos_from_ray;
 
-@group(0) @binding(0) var ssao_texture: texture_storage_2d<r32float, read_write>;
+@group(0) @binding(0) var ssao_texture: texture_storage_2d<r32float, write>;
 
 @group(0) @binding(1) var normals: texture_2d<f32>;
 
@@ -13,13 +13,13 @@ var<uniform> camera: CameraUniform;
 @compute @workgroup_size(8, 8, 1)
 fn compute_main(@builtin(global_invocation_id) id: vec3<u32>) {
     let pixel_coord = id.xy;
-    let ssao_size = 0.5 * vec2f(1.0 / camera.inv_screen_size.x, 1.0 / camera.inv_screen_size.y);
+    let ssao_size = textureDimensions(ssao_texture);
 
-    if(pixel_coord.x >= u32(ssao_size.x) || pixel_coord.y >= u32(ssao_size.y)) {
+    if(pixel_coord.x >= ssao_size.x || pixel_coord.y >= ssao_size.y) {
         return;
     }
 
-    compute_ssao(pixel_coord, ssao_size);
+    compute_ssao(pixel_coord, vec2f(ssao_size));
 }
 
 const radius: f32 = 0.2;
@@ -59,9 +59,8 @@ fn compute_ssao(pixel_coord: vec2<u32>, ssao_size: vec2f) {
 
     var fragPos = vec3f(0.0, 0.0, 0.0);
     if(loadedNormal.x == 0.0 && loadedNormal.y == 0.0 && loadedNormal.z == 0.0) {
-        let u_coord = (f32(2 * pixel_coord.x) * camera.inv_screen_size.x) * 2.0 - 1.0;
-        let v_coord = (f32(2 * pixel_coord.y) * camera.inv_screen_size.y) * 2.0 - 1.0;
-        fragPos = frag_pos_from_ray(camera, vec2f(u_coord, v_coord));
+        let uv_coord = (vec2f(2 * pixel_coord.xy) * camera.inv_screen_size) * 2.0 - 1.0;
+        fragPos = frag_pos_from_ray(camera, uv_coord);
         fragPos = (camera.view * vec4f(fragPos, 1.0)).xyz;
         normal = normalize((camera.view_tr_inv * vec4f(0.0, 0.0, 1.0, 1.0)).xyz);
     } else {
@@ -88,8 +87,8 @@ fn compute_ssao(pixel_coord: vec2<u32>, ssao_size: vec2f) {
             continue;
         }
 
-        let offset2 = camera.proj * vec4f(samplePos, 1.0);
-        let ndcPos = offset2.xy / offset2.w;
+        let offset = camera.proj * vec4f(samplePos, 1.0);
+        let ndcPos = offset.xy / offset.w;
         let uv = ndcPos * vec2f(0.5, -0.5) + vec2f(0.5);
         let screenCoord = vec2i(uv * ssao_size);
 


### PR DESCRIPTION
General line is preferring quality over performance for now:
1) Full-res for both MRT and SSAO textures
2) RGBA16 format to be able to use HW filtering for texture sampling
3) Bigger SSAO blur kernel
4) More SSAO samples + better noise data
5) Minor params adjustment