### PR TITLE
Get rid of VERTEX_WRITABLE_STORAGE feature

### DIFF
--- a/renderer/src/mesh/positioned_mesh.rs
+++ b/renderer/src/mesh/positioned_mesh.rs
@@ -8,6 +8,7 @@ use crate::utils::ReceiverExt;
 use tokio::sync::broadcast::Receiver;
 use wgpu::{BindGroup, BindGroupLayout, Buffer, ComputePass, RenderPass};
 use wgpu::util::{DeviceExt, DrawIndexedIndirectArgs};
+use crate::pipelines::IndirectInstancesLayout;
 
 pub struct PositionedMesh<T: MeshInstanceInput> {
     mesh: Mesh,
@@ -21,6 +22,7 @@ pub struct PositionedMesh<T: MeshInstanceInput> {
     pub instances_args_buffer: Option<Buffer>,
     instances_args_buffer_data: Vec<u8>,
     pub instances_bind_group: Option<BindGroup>,
+    pub instances_compute_bind_group: Option<BindGroup>,
     pub instances_args_bind_group: Option<BindGroup>,
 }
 
@@ -55,6 +57,7 @@ impl<T: MeshInstanceInput> PositionedMesh<T> {
             instances_args_buffer: None,
             instances_args_buffer_data: vec![],
             instances_bind_group: None,
+            instances_compute_bind_group: None,
             instances_args_bind_group: None
         }
     }
@@ -62,7 +65,7 @@ impl<T: MeshInstanceInput> PositionedMesh<T> {
     pub fn update(
         &mut self,
         global_context: &mut GlobalContext,
-        instances_bind_group_layout: Option<(&BindGroupLayout, &BindGroupLayout)>,
+        instances_bind_group_layout: Option<IndirectInstancesLayout>,
     ) {
         let cs_offset_updated = global_context.view_projection.cs_offset != self.cs_offset;
         self.cs_offset = global_context.view_projection.cs_offset;
@@ -96,28 +99,19 @@ impl<T: MeshInstanceInput> PositionedMesh<T> {
                     usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
                 });
 
-                self.instances_bind_group = Some(
-                    global_context
-                        .device()
-                        .create_bind_group(&wgpu::BindGroupDescriptor {
-                            layout: instances_bind_group_layout.0,
-                            entries: &[wgpu::BindGroupEntry {
-                                binding: 0,
-                                resource: self
-                                    .instance_buffer
-                                    .buffer
-                                    .as_ref()
-                                    .expect("Buffer should exist")
-                                    .as_entire_binding(),
-                            },
-                                wgpu::BindGroupEntry {
-                                    binding: 1,
-                                    resource: culled_buffer.as_entire_binding(),
-                                }],
-                            label: Some("instances_bind_group"),
-                        }),
-                );
 
+                self.instances_bind_group = Some(self.create_instance_bind_group(global_context, 
+                                                                                 instances_bind_group_layout.vertex_layout,
+                                                                                 &culled_buffer,
+                                                                                 "instances_bind_group",
+                ));
+
+                self.instances_compute_bind_group = Some(self.create_instance_bind_group(global_context,
+                                                                                 instances_bind_group_layout.compute_layout,
+                                                                                 &culled_buffer,
+                                                                                 "instances_compute_bind_group",
+                ));
+                
                 let instance_count = if self.attrs.len() <= 2 {
                     self.attrs.len()
                 } else {
@@ -146,7 +140,7 @@ impl<T: MeshInstanceInput> PositionedMesh<T> {
                     global_context
                         .device()
                         .create_bind_group(&wgpu::BindGroupDescriptor {
-                            layout: instances_bind_group_layout.1,
+                            layout: instances_bind_group_layout.common_args_layout,
                             entries: &[wgpu::BindGroupEntry {
                                 binding: 0,
                                 resource: indirect_args
@@ -162,6 +156,31 @@ impl<T: MeshInstanceInput> PositionedMesh<T> {
                 self.instances_args_bind_group = None;
             }
         }
+    }
+
+    fn create_instance_bind_group(&mut self, global_context: &mut GlobalContext,
+                                  instance_layout: &BindGroupLayout,
+                                  culled_buffer: &Buffer,
+                                  label: &'static str) -> BindGroup {
+        global_context
+            .device()
+            .create_bind_group(&wgpu::BindGroupDescriptor {
+                layout: instance_layout,
+                entries: &[wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: self
+                        .instance_buffer
+                        .buffer
+                        .as_ref()
+                        .expect("Buffer should exist")
+                        .as_entire_binding(),
+                },
+                    wgpu::BindGroupEntry {
+                        binding: 1,
+                        resource: culled_buffer.as_entire_binding(),
+                    }],
+                label: Some(label),
+            })
     }
 
     pub fn compute_instanced(

--- a/renderer/src/mesh_layers/general_mesh_layer.rs
+++ b/renderer/src/mesh_layers/general_mesh_layer.rs
@@ -123,11 +123,11 @@ impl<P: RenderPipeline> BaseMeshLayer for GeneralMeshLayer<P> {
             });
             self.render_pipeline.compute(&mut compute_pass, global_context);
             self.render_data_holder.run_mut_action(|mesh| {
-                if let (Some(instance_bind_group),
-                    Some(instance_args_bind_group)) = (mesh.instances_bind_group.as_ref(),
+                if let (Some(instances_compute_bind_group),
+                    Some(instance_args_bind_group)) = (mesh.instances_compute_bind_group.as_ref(),
                                                        mesh.instances_args_bind_group.as_ref()) {
                     self.render_pipeline.set_instance_bind_group_compute(&mut compute_pass,
-                                                                         instance_bind_group,
+                                                                         instances_compute_bind_group,
                                                                          instance_args_bind_group);
                     mesh.compute_instanced(&mut compute_pass, global_context);
                 }

--- a/renderer/src/pipelines/mesh_pipeline.rs
+++ b/renderer/src/pipelines/mesh_pipeline.rs
@@ -131,7 +131,7 @@ impl MeshPipeline {
 }
 
 impl WithSSAOTexture for MeshPipeline {
-    fn update_ssao_texture(&mut self, texture_view: &TextureView, global_context: &GlobalContext) {
+    fn update_ssao_texture(&mut self, _texture_view: &TextureView, _global_context: &GlobalContext) {
         // TODO
     }
 }
@@ -226,7 +226,7 @@ impl RenderPipeline for MeshPipeline {
     fn set_instance_bind_group_render(&mut self, _render_pass: &mut RenderPass, _instance_bind_group: &BindGroup) {
     }
 
-    fn get_instances_layouts(&self) -> Option<IndirectInstancesLayout> {
+    fn get_instances_layouts(&self) -> Option<IndirectInstancesLayout<'_>> {
         None
     }
 

--- a/renderer/src/pipelines/mesh_pipeline.rs
+++ b/renderer/src/pipelines/mesh_pipeline.rs
@@ -1,6 +1,6 @@
 use crate::draw_commands::MeshVertex;
 use crate::global_context::GlobalContext;
-use crate::pipelines::{OwnedFragmentState, OwnedRenderPipelineDescriptor, OwnedVertexState, RenderPipeline, WithSSAOTexture};
+use crate::pipelines::{IndirectInstancesLayout, OwnedFragmentState, OwnedRenderPipelineDescriptor, OwnedVertexState, RenderPipeline, WithSSAOTexture};
 use crate::textures::{create_simple_texture, TextureData, SAMPLE_COUNT};
 use crate::vertex_attrs::{GeneralInstanceInput, VertexAttrib};
 use std::borrow::Cow;
@@ -226,7 +226,7 @@ impl RenderPipeline for MeshPipeline {
     fn set_instance_bind_group_render(&mut self, _render_pass: &mut RenderPass, _instance_bind_group: &BindGroup) {
     }
 
-    fn get_instances_layouts(&self) -> Option<(&BindGroupLayout, &BindGroupLayout)> {
+    fn get_instances_layouts(&self) -> Option<IndirectInstancesLayout> {
         None
     }
 

--- a/renderer/src/pipelines/mod.rs
+++ b/renderer/src/pipelines/mod.rs
@@ -10,6 +10,12 @@ pub mod mesh_pipeline;
 pub mod shape_pipeline;
 pub mod screen_mesh_pipeline;
 
+pub struct IndirectInstancesLayout<'a> {
+    pub vertex_layout: &'a BindGroupLayout,
+    pub compute_layout: &'a BindGroupLayout,
+    pub common_args_layout: &'a BindGroupLayout,
+}
+
 pub trait RenderPipeline {
     type InstanceInputType: MeshInstanceInput;
 
@@ -26,7 +32,7 @@ pub trait RenderPipeline {
     fn set_instance_bind_group_compute(&mut self, compute_pass: &mut ComputePass, instance_bind_group: &BindGroup, instance_args_bind_group: &BindGroup);
     fn set_instance_bind_group_render(&mut self, render_pass: &mut RenderPass, instance_bind_group: &BindGroup);
 
-    fn get_instances_layouts(&self) -> Option<(&BindGroupLayout, &BindGroupLayout)>;
+    fn get_instances_layouts(&self) -> Option<IndirectInstancesLayout>;
 
     fn is_indirect(&self) -> bool;
     fn support_g_buf(&self) -> bool;

--- a/renderer/src/pipelines/mod.rs
+++ b/renderer/src/pipelines/mod.rs
@@ -32,7 +32,7 @@ pub trait RenderPipeline {
     fn set_instance_bind_group_compute(&mut self, compute_pass: &mut ComputePass, instance_bind_group: &BindGroup, instance_args_bind_group: &BindGroup);
     fn set_instance_bind_group_render(&mut self, render_pass: &mut RenderPass, instance_bind_group: &BindGroup);
 
-    fn get_instances_layouts(&self) -> Option<IndirectInstancesLayout>;
+    fn get_instances_layouts(&self) -> Option<IndirectInstancesLayout<'_>>;
 
     fn is_indirect(&self) -> bool;
     fn support_g_buf(&self) -> bool;

--- a/renderer/src/pipelines/screen_mesh_pipeline.rs
+++ b/renderer/src/pipelines/screen_mesh_pipeline.rs
@@ -132,7 +132,7 @@ impl RenderPipeline for ScreenMeshPipeline {
     fn set_instance_bind_group_render(&mut self, _render_pass: &mut RenderPass, _instance_bind_group: &BindGroup) {
     }
 
-    fn get_instances_layouts(&self) -> Option<IndirectInstancesLayout> {
+    fn get_instances_layouts(&self) -> Option<IndirectInstancesLayout<'_>> {
         None
     }
 

--- a/renderer/src/pipelines/screen_mesh_pipeline.rs
+++ b/renderer/src/pipelines/screen_mesh_pipeline.rs
@@ -1,6 +1,6 @@
 use crate::global_context::GlobalContext;
 use crate::pipelines::mesh_pipeline::MeshPipeline;
-use crate::pipelines::{OwnedRenderPipelineDescriptor, RenderPipeline, WithTexture};
+use crate::pipelines::{IndirectInstancesLayout, OwnedRenderPipelineDescriptor, RenderPipeline, WithTexture};
 use crate::textures::{create_simple_texture, TextureData};
 use crate::vertex_attrs::{MeshVertexWithUV, ShapeInstanceInput, TextInstanceInput, VertexAttrib};
 use std::borrow::Cow;
@@ -132,7 +132,7 @@ impl RenderPipeline for ScreenMeshPipeline {
     fn set_instance_bind_group_render(&mut self, _render_pass: &mut RenderPass, _instance_bind_group: &BindGroup) {
     }
 
-    fn get_instances_layouts(&self) -> Option<(&BindGroupLayout, &BindGroupLayout)> {
+    fn get_instances_layouts(&self) -> Option<IndirectInstancesLayout> {
         None
     }
 

--- a/renderer/src/pipelines/shape_pipeline.rs
+++ b/renderer/src/pipelines/shape_pipeline.rs
@@ -78,6 +78,11 @@ impl ShapePipeline {
         } else {
             ShaderStages::VERTEX
         };
+        let label = if is_compute_pipeline {
+            "shape_indirect_compute_buffer_layout"
+        } else {
+            "shape_indirect_buffer_layout"
+        };
         global_context.device().create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
             entries: &[wgpu::BindGroupLayoutEntry {
                 binding: 0,
@@ -99,7 +104,7 @@ impl ShapePipeline {
                     },
                     count: None,
                 }],
-            label: Some("shape_indirect_buffer_layout"),
+            label: Some(label),
         })
     }
 }

--- a/renderer/src/pipelines/shape_pipeline.rs
+++ b/renderer/src/pipelines/shape_pipeline.rs
@@ -181,7 +181,7 @@ impl RenderPipeline for ShapePipeline {
         render_pass.set_bind_group(2, instance_bind_group, &[]);
     }
 
-    fn get_instances_layouts(&self) -> Option<IndirectInstancesLayout> {
+    fn get_instances_layouts(&self) -> Option<IndirectInstancesLayout<'_>> {
         if self.indirect {
             Some(IndirectInstancesLayout {
                 vertex_layout: &self.indirect_instances_layout,

--- a/renderer/src/pipelines/shape_pipeline.rs
+++ b/renderer/src/pipelines/shape_pipeline.rs
@@ -1,6 +1,6 @@
 use crate::global_context::GlobalContext;
 use crate::pipelines::mesh_pipeline::MeshPipeline;
-use crate::pipelines::{OwnedRenderPipelineDescriptor, RenderPipeline};
+use crate::pipelines::{IndirectInstancesLayout, OwnedRenderPipelineDescriptor, RenderPipeline};
 use crate::vertex_attrs::{ShapeInstanceInput, ShapeVertex, VertexAttrib};
 use std::borrow::Cow;
 use wesl::include_wesl;
@@ -10,6 +10,7 @@ pub struct ShapePipeline {
     mesh_pipeline: MeshPipeline,
     vs_func_name: Option<&'static str>,
     indirect_instances_layout: BindGroupLayout,
+    indirect_compute_instances_layout: BindGroupLayout,
     indirect_instances_args_layout: BindGroupLayout,
     culling_compute_pipeline: ComputePipeline,
     indirect: bool
@@ -20,30 +21,8 @@ impl ShapePipeline {
     const SHADER_STYLE_GROUP_INDEX: u32 = 1;
 
     pub fn new(global_context: &GlobalContext, vs_func_name: Option<&'static str>, indirect: bool) -> Self {
-        let indirect_instances_layout = global_context.device().create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-            entries: &[wgpu::BindGroupLayoutEntry {
-                binding: 0,
-                visibility: ShaderStages::VERTEX | ShaderStages::COMPUTE,
-                ty: wgpu::BindingType::Buffer {
-                    ty: wgpu::BufferBindingType::Storage { read_only: false },
-                    has_dynamic_offset: false,
-                    min_binding_size: None,
-                },
-                count: None,
-            },
-                wgpu::BindGroupLayoutEntry {
-                    binding: 1,
-                    visibility: ShaderStages::VERTEX | ShaderStages::COMPUTE,
-                    ty: wgpu::BindingType::Buffer {
-                        ty: wgpu::BufferBindingType::Storage { read_only: false },
-                        has_dynamic_offset: false,
-                        min_binding_size: None,
-                    },
-                    count: None,
-                }],
-            label: Some("shape_indirect_buffer_layout"),
-        });
-
+        let indirect_instances_layout = Self::create_indirect_layout(global_context, false);
+        let indirect_compute_instances_layout = Self::create_indirect_layout(global_context, true);
         let indirect_instances_args_layout = global_context.device().create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
             entries: &[wgpu::BindGroupLayoutEntry {
                 binding: 0,
@@ -64,9 +43,12 @@ impl ShapePipeline {
             source: ShaderSource::Wgsl(Cow::from(include_wesl!("shape_culling"))),
         });
 
+
         let culling_pipeline_layout = global_context.device().create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: Some("Shape Compute Pipeline Layout"),
-            bind_group_layouts: &[&mesh_pipeline.bind_group_layout, &indirect_instances_layout, &indirect_instances_args_layout],
+            bind_group_layouts: &[&mesh_pipeline.bind_group_layout,
+                &indirect_compute_instances_layout,
+                &indirect_instances_args_layout],
             ..Default::default()
         });
 
@@ -83,10 +65,42 @@ impl ShapePipeline {
             mesh_pipeline,
             vs_func_name,
             indirect_instances_layout,
+            indirect_compute_instances_layout,
             indirect_instances_args_layout,
             culling_compute_pipeline,
             indirect
         }
+    }
+
+    fn create_indirect_layout(global_context: &GlobalContext, is_compute_pipeline: bool) -> BindGroupLayout {
+        let visibility = if is_compute_pipeline {
+            ShaderStages::COMPUTE
+        } else {
+            ShaderStages::VERTEX
+        };
+        global_context.device().create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            entries: &[wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Storage { read_only: !is_compute_pipeline },
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                },
+                count: None,
+            },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Storage { read_only: !is_compute_pipeline },
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                }],
+            label: Some("shape_indirect_buffer_layout"),
+        })
     }
 }
 
@@ -162,9 +176,13 @@ impl RenderPipeline for ShapePipeline {
         render_pass.set_bind_group(2, instance_bind_group, &[]);
     }
 
-    fn get_instances_layouts(&self) -> Option<(&BindGroupLayout, &BindGroupLayout)> {
+    fn get_instances_layouts(&self) -> Option<IndirectInstancesLayout> {
         if self.indirect {
-            Some((&self.indirect_instances_layout, &self.indirect_instances_args_layout))
+            Some(IndirectInstancesLayout {
+                vertex_layout: &self.indirect_instances_layout,
+                compute_layout: &self.indirect_compute_instances_layout,
+                common_args_layout: &self.indirect_instances_args_layout,
+            })
         } else {
             None
         }

--- a/renderer/src/shaders/shape_shader.wgsl
+++ b/renderer/src/shaders/shape_shader.wgsl
@@ -15,10 +15,10 @@ var<uniform> camera: CameraUniform;
 var<storage, read> styles: array<StyleUniform>;
 
 @group(2) @binding(0)
-var<storage, read_write> indirect_instances: array<InstanceInput>;
+var<storage, read> indirect_instances: array<InstanceInput>;
 
 @group(2) @binding(1)
-var<storage, read_write> culled: array<u32>;
+var<storage, read> culled: array<u32>;
 
 struct VertexInput {
     @builtin(instance_index) instance_index : u32,

--- a/winit-run/src/main.rs
+++ b/winit-run/src/main.rs
@@ -33,8 +33,7 @@ fn main() {
     let (slint_map_event_sender, slint_map_event_receiver) = mpsc::channel();
 
     let mut wgpu_settings = WGPUSettings::default();
-    wgpu_settings.device_required_features =
-        Features::VERTEX_WRITABLE_STORAGE | Features::CLEAR_TEXTURE | Features::IMMEDIATES;
+    wgpu_settings.device_required_features = Features::CLEAR_TEXTURE | Features::IMMEDIATES;
     wgpu_settings.device_required_limits = Limits::downlevel_defaults();
     wgpu_settings.device_required_limits.max_immediate_size = 4;
 


### PR DESCRIPTION
Most of tile-based GPUs(e.g. Pixel 9) do not support it, so it causes a crash.
But this requires it have a separated bind groups for vertex and compute shaders.