### PR TITLE
Glyph outlines

### DIFF
--- a/renderer/src/mesh/mesh.rs
+++ b/renderer/src/mesh/mesh.rs
@@ -39,6 +39,7 @@ impl Mesh {
                 position: [0.0, 0.0, 0.0],
                 normals: [0.0, 0.0, 0.0],
             },
+            color: [0.0, 0.0, 0.0],
             uv: [0.0, 1.0],
         });
         geometry_buffer.vertices.push(MeshVertexWithUV {
@@ -46,6 +47,7 @@ impl Mesh {
                 position: [width, 0.0, 0.0],
                 normals: [0.0, 0.0, 0.0],
             },
+            color: [0.0, 0.0, 0.0],
             uv: [1.0, 1.0],
         });
         geometry_buffer.vertices.push(MeshVertexWithUV {
@@ -53,6 +55,7 @@ impl Mesh {
                 position: [0.0, height, 0.0],
                 normals: [0.0, 0.0, 0.0],
             },
+            color: [0.0, 0.0, 0.0],
             uv: [0.0, 0.0],
         });
         geometry_buffer.vertices.push(MeshVertexWithUV {
@@ -60,6 +63,7 @@ impl Mesh {
                 position: [width, height, 0.0],
                 normals: [0.0, 0.0, 0.0],
             },
+            color: [0.0, 0.0, 0.0],
             uv: [1.0, 0.0],
         });
 

--- a/renderer/src/shaders/screen_mesh_shader.wgsl
+++ b/renderer/src/shaders/screen_mesh_shader.wgsl
@@ -12,7 +12,8 @@ var<immediate> texture_type: TextureType;
 struct VertexInput {
     @location(0) position: vec3<f32>,
     @location(1) normal: vec3<f32>,
-    @location(2) uv: vec2<f32>,
+    @location(2) color: vec3<f32>,
+    @location(3) uv: vec2<f32>,
 }
 
 struct InstanceInput {
@@ -27,7 +28,7 @@ struct InstanceInput {
 
 struct VertexOutput {
     @builtin(position) clip_position: vec4<f32>,
-    @location(0) color_alpha: f32,
+    @location(0) color: vec4<f32>,
     @location(1) uv: vec2<f32>,
 }
 
@@ -47,8 +48,6 @@ fn vs_main(
     let model_position = model_matrix * vec4(model.position.xyz, 1.0);
     let ratio_fixed_modelpos = vec4(model_position.xy * vec2(2.0*camera.inv_screen_size.x, 2.0*camera.inv_screen_size.y), model_position.z, 1.0);
 
-    out.color_alpha = pos.color_alpha;
-
     var coord = vec4<f32>(pos.position.xy, 0.0, 1.0);
     if pos.screen_space == 0 {
         coord = camera.view_proj * coord;
@@ -58,6 +57,7 @@ fn vs_main(
         coord.y *= camera.inv_screen_size.y;
         coord.y = 2.0*(coord.y - 0.5) * -1.0;
     }
+    out.color = vec4f(model.color, pos.color_alpha);
     out.uv = model.uv;
     out.clip_position = vec4<f32>(ratio_fixed_modelpos.xyz, 0.0) + vec4(coord.xyz/coord.w, 1.0);
     return out;
@@ -75,7 +75,7 @@ var s_compare: sampler_comparison;
 
 @fragment
 fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
-    return vec4(0.0, 0.0, 0.0, in.color_alpha);
+    return in.color;
 }
 
 const tex_border_x: f32 = 0.01;

--- a/renderer/src/text/glyph_cache.rs
+++ b/renderer/src/text/glyph_cache.rs
@@ -1,7 +1,7 @@
 use crate::mesh::mesh::{Mesh, StyledRangeInfo};
 use crate::text::default_face_wrapper::DefaultFaceWrapper;
 use crate::text::glyph_tesselator::GlyphTesselator;
-use glam::Vec2;
+use lyon::lyon_tessellation::VertexBuffers;
 use rustc_hash::FxHashMap;
 use rustybuzz::ttf_parser::GlyphId;
 use std::sync::Arc;
@@ -26,8 +26,11 @@ impl GlyphCache {
         let mesh = self.glyph_mesh_map.entry(glyph_id).or_insert_with(|| {
             let mut path_builder = GlyphTesselator::new(DefaultFaceWrapper::MAX_SCALE);
             self.face.outline_glyph(glyph_id, &mut path_builder);
-            let glyph_buf = path_builder.tessellate_fill(Vec2::new(0.0, 0.0f32), Color::BLUE);
-            Mesh::create(&device, &glyph_buf, StyledRangeInfo(0, ""))
+            let mut buffer = VertexBuffers::new();
+            let path = path_builder.create_path();
+            path_builder.tessellate_stroke(&mut buffer, &path, 4.0, Color::WHITE);
+            path_builder.tessellate_fill(&mut buffer, &path, Color::BLACK);
+            Mesh::create(&device, &buffer, StyledRangeInfo(0, ""))
         });
 
         mesh

--- a/renderer/src/text/glyph_cache.rs
+++ b/renderer/src/text/glyph_cache.rs
@@ -26,7 +26,7 @@ impl GlyphCache {
         let mesh = self.glyph_mesh_map.entry(glyph_id).or_insert_with(|| {
             let mut path_builder = GlyphTesselator::new(DefaultFaceWrapper::MAX_SCALE);
             self.face.outline_glyph(glyph_id, &mut path_builder);
-            let glyph_buf = path_builder.tessellate_fill(Vec2::new(0.0, 0.0f32), Color::RED);
+            let glyph_buf = path_builder.tessellate_fill(Vec2::new(0.0, 0.0f32), Color::BLUE);
             Mesh::create(&device, &glyph_buf, StyledRangeInfo(0, ""))
         });
 

--- a/renderer/src/text/glyph_tesselator.rs
+++ b/renderer/src/text/glyph_tesselator.rs
@@ -1,11 +1,9 @@
 use glam::Vec2;
 use crate::draw_commands::MeshVertex;
 use crate::vertex_attrs::MeshVertexWithUV;
-use lyon::lyon_tessellation::{
-    BuffersBuilder, FillOptions, FillTessellator, FillVertex, FillVertexConstructor,
-    StrokeVertexConstructor, VertexBuffers,
-};
-use lyon::path::{Builder, Path};
+use lyon::lyon_tessellation::{BuffersBuilder, FillOptions, FillTessellator, FillVertex, FillVertexConstructor, LineCap, StrokeVertexConstructor, VertexBuffers};
+use lyon::path::{Builder, LineJoin, Path};
+use lyon::tessellation::{StrokeOptions, StrokeTessellator};
 use rustybuzz::ttf_parser::OutlineBuilder;
 use wgpu::Color;
 #[derive(Clone)]
@@ -27,6 +25,30 @@ impl GlyphTesselator {
             .tessellate(
                 &self.builder.build(),
                 &FillOptions::default().with_fill_rule(lyon::path::FillRule::NonZero),
+                &mut BuffersBuilder::new(&mut buffer, vertex_constructor),
+            )
+            .is_ok()
+        {
+            buffer
+        } else {
+            panic!("Tessellate failed.");
+        }
+    }
+
+    pub(crate) fn tessellate_stroke(
+        self,
+        offset: Vec2,
+        color: Color,
+    ) -> VertexBuffers<MeshVertexWithUV, u32> {
+        let mut buffer = VertexBuffers::new();
+        let vertex_constructor = GlyphVertexConstructor { offset, color };
+        let mut tessellator = StrokeTessellator::new();
+        if tessellator
+            .tessellate(
+                &self.builder.build(),
+                &StrokeOptions::default()
+                    .with_line_cap(LineCap::Round)
+                    .with_line_join(LineJoin::Round).with_line_width(12.0),
                 &mut BuffersBuilder::new(&mut buffer, vertex_constructor),
             )
             .is_ok()
@@ -94,6 +116,7 @@ impl FillVertexConstructor<MeshVertexWithUV> for GlyphVertexConstructor {
                 ],
                 normals: [0.0, 0.0, 0.0],
             },
+            color: [self.color.r as f32, self.color.g as f32, self.color.b as f32],
             uv: [0.0, 0.0],
         }
     }
@@ -110,6 +133,7 @@ impl StrokeVertexConstructor<MeshVertexWithUV> for GlyphVertexConstructor {
                 ],
                 normals: [0.0, 0.0, 0.0],
             },
+            color: [self.color.r as f32, self.color.g as f32, self.color.b as f32],
             uv: [0.0, 0.0],
         }
     }

--- a/renderer/src/text/glyph_tesselator.rs
+++ b/renderer/src/text/glyph_tesselator.rs
@@ -1,10 +1,11 @@
-use glam::Vec2;
 use crate::draw_commands::MeshVertex;
 use crate::vertex_attrs::MeshVertexWithUV;
-use lyon::lyon_tessellation::{BuffersBuilder, FillOptions, FillTessellator, FillVertex, FillVertexConstructor, LineCap, StrokeVertexConstructor, VertexBuffers};
-use lyon::path::{Builder, LineJoin, Path};
+use glam::Vec2;
+use lyon::lyon_tessellation::{BuffersBuilder, FillOptions, FillTessellator, FillVertex, FillVertexConstructor, LineCap, LineJoin, StrokeVertexConstructor, VertexBuffers};
+use lyon::path::{Builder, Path};
 use lyon::tessellation::{StrokeOptions, StrokeTessellator};
 use rustybuzz::ttf_parser::OutlineBuilder;
+use std::mem;
 use wgpu::Color;
 #[derive(Clone)]
 pub struct GlyphTesselator {
@@ -13,49 +14,50 @@ pub struct GlyphTesselator {
 }
 
 impl GlyphTesselator {
+    pub(crate) fn create_path(&mut self) -> Path {
+        mem::replace(&mut self.builder, Builder::new()).build()
+    }
     pub(crate) fn tessellate_fill(
-        self,
-        offset: Vec2,
+        &self,
+        buffer: &mut VertexBuffers<MeshVertexWithUV, u32>,
+        path: &Path,
         color: Color,
-    ) -> VertexBuffers<MeshVertexWithUV, u32> {
-        let mut buffer = VertexBuffers::new();
-        let vertex_constructor = GlyphVertexConstructor { offset, color };
+    ) {
+        let vertex_constructor = GlyphVertexConstructor { offset: Vec2::new(0.0, 0.0), color };
         let mut tessellator = FillTessellator::new();
-        if tessellator
+        if !tessellator
             .tessellate(
-                &self.builder.build(),
+                path,
                 &FillOptions::default().with_fill_rule(lyon::path::FillRule::NonZero),
-                &mut BuffersBuilder::new(&mut buffer, vertex_constructor),
+                &mut BuffersBuilder::new(buffer, vertex_constructor),
             )
             .is_ok()
         {
-            buffer
-        } else {
-            panic!("Tessellate failed.");
+            panic!("Glyph fill tessellate failed.");
         }
     }
 
     pub(crate) fn tessellate_stroke(
-        self,
-        offset: Vec2,
+        &self,
+        buffer: &mut VertexBuffers<MeshVertexWithUV, u32>,
+        path: &Path,
+        size: f32,
         color: Color,
-    ) -> VertexBuffers<MeshVertexWithUV, u32> {
-        let mut buffer = VertexBuffers::new();
-        let vertex_constructor = GlyphVertexConstructor { offset, color };
+    ) {
+        let vertex_constructor = GlyphVertexConstructor { offset: Vec2::new(0.0, 0.0), color };
         let mut tessellator = StrokeTessellator::new();
-        if tessellator
+        if !tessellator
             .tessellate(
-                &self.builder.build(),
+                path,
                 &StrokeOptions::default()
+                    .with_line_join(LineJoin::Round)
                     .with_line_cap(LineCap::Round)
-                    .with_line_join(LineJoin::Round).with_line_width(12.0),
-                &mut BuffersBuilder::new(&mut buffer, vertex_constructor),
+                    .with_line_width(size),
+                &mut BuffersBuilder::new(buffer, vertex_constructor),
             )
             .is_ok()
         {
-            buffer
-        } else {
-            panic!("Tessellate failed.");
+            panic!("GLyph stroke tessellate failed.");
         }
     }
 }

--- a/renderer/src/vertex_attrs.rs
+++ b/renderer/src/vertex_attrs.rs
@@ -28,12 +28,13 @@ pub struct ShapeVertex {
 #[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
 pub struct MeshVertexWithUV {
     pub mesh_vertex: MeshVertex,
+    pub color: [f32; 3],
     pub uv: [f32; 2],
 }
 
 impl VertexAttrib for MeshVertexWithUV {
     const ATTRIBUTES: &[VertexAttribute] =
-        &wgpu::vertex_attr_array![0 => Float32x3, 1 => Float32x3, 2 => Float32x2];
+        &wgpu::vertex_attr_array![0 => Float32x3, 1 => Float32x3, 2=> Float32x3, 3 => Float32x2];
 
     const STEP_MODE: VertexStepMode = wgpu::VertexStepMode::Vertex;
 }


### PR DESCRIPTION
Initial simple implementation uses stroke tessellation atop of fill tessellation.
+ screen mesh color is now supported