### PR TITLE
More optimisations

### DIFF
--- a/renderer/src/canvas_api.rs
+++ b/renderer/src/canvas_api.rs
@@ -10,7 +10,7 @@ use crate::styles::style_id::StyleId;
 use crate::styles::style_store::StyleStore;
 use crate::svg::svg_parser::svg_parse;
 use crate::vertex_attrs::ShapeVertex;
-use glam::{DVec3, Vec3};
+use glam::{DVec3, Vec2, Vec3};
 use lyon::geom::euclid::{point2, Box2D};
 use lyon::lyon_tessellation::{
     BuffersBuilder, FillOptions, FillTessellator, FillVertex, StrokeOptions, StrokeTessellator,
@@ -240,20 +240,24 @@ impl CanvasApi {
         let initial_index = self.geometry.indices.len();
         match geom_type {
             GeometryType::Polyline(options) => {
-                self.tessellate_stroke_path(&data.path, options, |vertex| ShapeVertex {
-                    position: [vertex.position().x, vertex.position().y],
-                    normals: [vertex.normal().x, vertex.normal().y],
-                    uv_dist: [0.0, 0.0, vertex.advancement()],
-                    style_index: style_index as u32,
+                self.tessellate_stroke_path(&data.path, options, |vertex| {
+                    ShapeVertex::new([vertex.position().x, vertex.position().y],
+                                     [vertex.normal().x, vertex.normal().y],
+                                     [0.0, 0.0],
+                                     vertex.advancement(),
+                                     style_index as u8,
+                    )
                 });
             }
             GeometryType::Polygon => {
-                Self::tessellate_fill_path(&data.path, &mut self.geometry, |vertex| ShapeVertex {
-                    position: [vertex.position().x, vertex.position().y],
-                    normals: [0.0, 0.0],
-                    uv_dist: [0.0, 0.0, 0.0], // fill doesn't have length
-                    style_index: style_index as u32,
-                });
+                Self::tessellate_fill_path(&data.path, &mut self.geometry, |vertex|
+                    ShapeVertex::new([vertex.position().x, vertex.position().y],
+                                     [0.0, 0.0],
+                                     [0.0, 0.0],
+                                     0.0,
+                                     style_index as u8,
+                    ),
+                );
             }
         }
         let last_index = self.geometry.indices.len();
@@ -298,12 +302,14 @@ impl CanvasApi {
                     builder.add_rounded_rectangle(&rect, &BorderRadii::new(10.0), Winding::Positive);
                     let path = builder.build();
 
-                    Self::tessellate_fill_path(&path, &mut mesh, |vertex| ShapeVertex {
-                        position: [vertex.position().x, vertex.position().y],
-                        normals: [0.0, 0.0],
-                        uv_dist: [0.0, 0.0, 0.0], // fill doesn't have length
-                        style_index: background_style_index as u32,
-                    });
+                    Self::tessellate_fill_path(&path, &mut mesh, |vertex|
+                        ShapeVertex::new([vertex.position().x, vertex.position().y],
+                                         [0.0, 0.0],
+                                         [0.0, 0.0],
+                                         0.0,
+                                         background_style_index as u8,
+                        )
+                    );
                 }
 
                 svg_parse(data.icon.1, &mut mesh, data.size, style_index);

--- a/renderer/src/mesh/mesh.rs
+++ b/renderer/src/mesh/mesh.rs
@@ -1,4 +1,3 @@
-use crate::draw_commands::MeshVertex;
 use crate::mesh::InstanceBuffer;
 use crate::vertex_attrs::MeshVertexWithUV;
 use bytemuck::{NoUninit, Pod};
@@ -35,34 +34,22 @@ impl Mesh {
     pub fn quad(device: &Device, width: f32, height: f32) -> Self {
         let mut geometry_buffer: VertexBuffers<MeshVertexWithUV, u32> = VertexBuffers::new();
         geometry_buffer.vertices.push(MeshVertexWithUV {
-            mesh_vertex: MeshVertex {
-                position: [0.0, 0.0, 0.0],
-                normals: [0.0, 0.0, 0.0],
-            },
+            position: [0.0, 0.0],
             color: [0.0, 0.0, 0.0],
             uv: [0.0, 1.0],
         });
         geometry_buffer.vertices.push(MeshVertexWithUV {
-            mesh_vertex: MeshVertex {
-                position: [width, 0.0, 0.0],
-                normals: [0.0, 0.0, 0.0],
-            },
+            position: [width, 0.0],
             color: [0.0, 0.0, 0.0],
             uv: [1.0, 1.0],
         });
         geometry_buffer.vertices.push(MeshVertexWithUV {
-            mesh_vertex: MeshVertex {
-                position: [0.0, height, 0.0],
-                normals: [0.0, 0.0, 0.0],
-            },
+            position: [0.0, height],
             color: [0.0, 0.0, 0.0],
             uv: [0.0, 0.0],
         });
         geometry_buffer.vertices.push(MeshVertexWithUV {
-            mesh_vertex: MeshVertex {
-                position: [width, height, 0.0],
-                normals: [0.0, 0.0, 0.0],
-            },
+            position: [width, height],
             color: [0.0, 0.0, 0.0],
             uv: [1.0, 0.0],
         });

--- a/renderer/src/mesh/mesh.rs
+++ b/renderer/src/mesh/mesh.rs
@@ -33,26 +33,20 @@ impl Mesh {
 
     pub fn quad(device: &Device, width: f32, height: f32) -> Self {
         let mut geometry_buffer: VertexBuffers<MeshVertexWithUV, u32> = VertexBuffers::new();
-        geometry_buffer.vertices.push(MeshVertexWithUV {
-            position: [0.0, 0.0],
-            color: [0.0, 0.0, 0.0],
-            uv: [0.0, 1.0],
-        });
-        geometry_buffer.vertices.push(MeshVertexWithUV {
-            position: [width, 0.0],
-            color: [0.0, 0.0, 0.0],
-            uv: [1.0, 1.0],
-        });
-        geometry_buffer.vertices.push(MeshVertexWithUV {
-            position: [0.0, height],
-            color: [0.0, 0.0, 0.0],
-            uv: [0.0, 0.0],
-        });
-        geometry_buffer.vertices.push(MeshVertexWithUV {
-            position: [width, height],
-            color: [0.0, 0.0, 0.0],
-            uv: [1.0, 0.0],
-        });
+        geometry_buffer.vertices.push(MeshVertexWithUV::new([0.0, 0.0],
+                                                            [0.0, 0.0, 0.0],
+                                                            [0.0, 1.0]));
+
+        geometry_buffer.vertices.push(MeshVertexWithUV::new([width, 0.0],
+                                                            [0.0, 0.0, 0.0],
+                                                            [1.0, 1.0]));
+
+        geometry_buffer.vertices.push(MeshVertexWithUV::new([0.0, height],
+                                                            [0.0, 0.0, 0.0],
+                                                            [0.0, 0.0]));
+        geometry_buffer.vertices.push(MeshVertexWithUV::new([width, height],
+                                                            [0.0, 0.0, 0.0],
+                                                            [1.0, 0.0]));
 
         geometry_buffer.indices.push(0);
         geometry_buffer.indices.push(2);

--- a/renderer/src/pass_nodes/main_pass_node.rs
+++ b/renderer/src/pass_nodes/main_pass_node.rs
@@ -266,7 +266,8 @@ impl PassNode for MainPassNode {
                     b: 0.961,
                     a: 1.0,
                 }),
-                store: wgpu::StoreOp::Store,
+                // FYI!! Discard output! It improves MSAA drastically on low-end devices
+                store: wgpu::StoreOp::Discard,
             },
             depth_slice: None,
         };

--- a/renderer/src/shaders/common.wgsl
+++ b/renderer/src/shaders/common.wgsl
@@ -23,46 +23,66 @@ fn shadow_map(t_depth: texture_depth_2d, s_compare: sampler_comparison, coord: v
 @if(CASTANO)
 fn castano(t_depth: texture_depth_2d, s_compare: sampler_comparison, coord: vec2f, depth_with_bias: f32) -> f32 {
     let tex_size = vec2f(textureDimensions(t_depth));
-    let texelSize = 1.0 / tex_size;
+    let texel_size = 1.0 / tex_size;
 
     let uv = coord * tex_size;
-    var base_uv = floor(uv + 0.5);
-    let s = (uv.x + 0.5 - base_uv.x);
-    let t = (uv.y + 0.5 - base_uv.y);
-    base_uv -= 0.5;
-    base_uv *= texelSize;
+    let base_uv_pixels = floor(uv + 0.5);
 
-    let uw0 = (4.0 - 3.0 * s);
-    let uw1 = 7.0;
-    let uw2 = (1.0 + 3.0 * s);
+    let st = uv + 0.5 - base_uv_pixels;
+    let s = st.x;
+    let t = st.y;
+    let base_uv = (base_uv_pixels - 0.5) * texel_size;
 
-    let u0 = (3.0 - 2.0 * s) / uw0 - 2.0;
-    let u1 = (3.0 + s) / uw1;
-    let u2 = s / uw2 + 2.0;
+    let uw = vec3f(4.0 - 3.0 * s, 7.0, 1.0 + 3.0 * s);
+    let vw = vec3f(4.0 - 3.0 * t, 7.0, 1.0 + 3.0 * t);
 
-    let vw0 = (4.0 - 3.0 * t);
-    let vw1 = 7.0;
-    let vw2 = (1.0 + 3.0 * t);
+    let inv_uw = 1.0 / uw;
+    let inv_vw = 1.0 / vw;
 
-    let v0 = (3.0 - 2.0 * t) / vw0 - 2.0;
-    let v1 = (3.0 + t) / vw1;
-    let v2 = t / vw2 + 2.0;
+    let u_offsets = vec3f(3.0 - 2.0 * s, 3.0 + s, s) * inv_uw + vec3f(-2.0, 0.0, 2.0);
+    let v_offsets = vec3f(3.0 - 2.0 * t, 3.0 + t, t) * inv_vw + vec3f(-2.0, 0.0, 2.0);
+
+    let u_tex = u_offsets * texel_size.x;
+    let v_tex = v_offsets * texel_size.y;
+
+    let c_bl = textureSampleCompare(t_depth, s_compare, base_uv + vec2f(u_tex.x, v_tex.x), depth_with_bias); // Bottom-Left
+    let c_br = textureSampleCompare(t_depth, s_compare, base_uv + vec2f(u_tex.z, v_tex.x), depth_with_bias); // Bottom-Right
+    let c_tl = textureSampleCompare(t_depth, s_compare, base_uv + vec2f(u_tex.x, v_tex.z), depth_with_bias); // Top-Left
+    let c_tr = textureSampleCompare(t_depth, s_compare, base_uv + vec2f(u_tex.z, v_tex.z), depth_with_bias); // Top-Right
+
+    let corner_sum = c_bl + c_br + c_tl + c_tr;
+
+    // Out if fully unshadowed (4.0) or fully shadowed (0.0)
+    if (corner_sum == 4.0) {
+        return 1.0;
+    }
+    if (corner_sum == 0.0) {
+        return 0.0;
+    }
+
+    let c_bm = textureSampleCompare(t_depth, s_compare, base_uv + vec2f(u_tex.y, v_tex.x), depth_with_bias); // Bottom-Middle
+
+    let c_ml = textureSampleCompare(t_depth, s_compare, base_uv + vec2f(u_tex.x, v_tex.y), depth_with_bias); // Middle-Left
+    let c_mm = textureSampleCompare(t_depth, s_compare, base_uv + vec2f(u_tex.y, v_tex.y), depth_with_bias); // Middle-Middle
+    let c_mr = textureSampleCompare(t_depth, s_compare, base_uv + vec2f(u_tex.z, v_tex.y), depth_with_bias); // Middle-Right
+
+    let c_tm = textureSampleCompare(t_depth, s_compare, base_uv + vec2f(u_tex.y, v_tex.z), depth_with_bias); // Top-Middle
 
     var sum = 0.0;
+    sum += uw.x * vw.x * c_bl;
+    sum += uw.y * vw.x * c_bm;
+    sum += uw.z * vw.x * c_br;
 
-    sum += uw0 * vw0 * textureSampleCompare(t_depth, s_compare, base_uv + (vec2(u0, v0) * texelSize), depth_with_bias);
-    sum += uw1 * vw0 * textureSampleCompare(t_depth, s_compare, base_uv + (vec2(u1, v0) * texelSize), depth_with_bias);
-    sum += uw2 * vw0 * textureSampleCompare(t_depth, s_compare, base_uv + (vec2(u2, v0) * texelSize), depth_with_bias);
+    sum += uw.x * vw.y * c_ml;
+    sum += uw.y * vw.y * c_mm;
+    sum += uw.z * vw.y * c_mr;
 
-    sum += uw0 * vw1 * textureSampleCompare(t_depth, s_compare, base_uv + (vec2(u0, v1) * texelSize), depth_with_bias);
-    sum += uw1 * vw1 * textureSampleCompare(t_depth, s_compare, base_uv + (vec2(u1, v1) * texelSize), depth_with_bias);
-    sum += uw2 * vw1 * textureSampleCompare(t_depth, s_compare, base_uv + (vec2(u2, v1) * texelSize), depth_with_bias);
+    sum += uw.x * vw.z * c_tl;
+    sum += uw.y * vw.z * c_tm;
+    sum += uw.z * vw.z * c_tr;
 
-    sum += uw0 * vw2 * textureSampleCompare(t_depth, s_compare, base_uv + (vec2(u0, v2) * texelSize), depth_with_bias);
-    sum += uw1 * vw2 * textureSampleCompare(t_depth, s_compare, base_uv + (vec2(u1, v2) * texelSize), depth_with_bias);
-    sum += uw2 * vw2 * textureSampleCompare(t_depth, s_compare, base_uv + (vec2(u2, v2) * texelSize), depth_with_bias);
-
-    return sum * (1.0 / 144.0);
+    // 1.0 / 144.0
+    return sum * 0.006944444;
 }
 
 fn pcf(t_depth: texture_depth_2d, s_compare: sampler_comparison, coord: vec2f, blur_size: f32, depth_with_bias: f32) -> f32 {

--- a/renderer/src/shaders/screen_mesh_shader.wgsl
+++ b/renderer/src/shaders/screen_mesh_shader.wgsl
@@ -11,7 +11,7 @@ var<immediate> texture_type: TextureType;
 
 struct VertexInput {
     @location(0) position: vec2<f32>,
-    @location(1) color: vec3<f32>,
+    @location(1) color: vec4<f32>,
     @location(2) uv: vec2<f32>,
 }
 
@@ -57,7 +57,7 @@ fn vs_main(
         coord.y *= camera.inv_screen_size.y;
         coord.y = 2.0*(coord.y - 0.5) * -1.0;
     }
-    out.color = vec4f(model.color, pos.color_alpha);
+    out.color = vec4f(model.color.rgb, pos.color_alpha);
     out.uv = model.uv;
     out.clip_position = vec4<f32>(ratio_fixed_modelpos.xyz, 0.0) + vec4(coord.xyz/coord.w, 1.0);
 

--- a/renderer/src/shaders/screen_mesh_shader.wgsl
+++ b/renderer/src/shaders/screen_mesh_shader.wgsl
@@ -10,10 +10,9 @@ var<uniform> camera: CameraUniform;
 var<immediate> texture_type: TextureType;
 
 struct VertexInput {
-    @location(0) position: vec3<f32>,
-    @location(1) normal: vec3<f32>,
-    @location(2) color: vec3<f32>,
-    @location(3) uv: vec2<f32>,
+    @location(0) position: vec2<f32>,
+    @location(1) color: vec3<f32>,
+    @location(2) uv: vec2<f32>,
 }
 
 struct InstanceInput {
@@ -46,7 +45,7 @@ fn vs_main(
             pos.model_matrix_2,
             pos.model_matrix_3,
     );
-    let model_position = model_matrix * vec4(model.position.xyz, 1.0);
+    let model_position = model_matrix * vec4(model.position, 0.0, 1.0);
     let ratio_fixed_modelpos = vec4(model_position.xy * vec2(2.0*camera.inv_screen_size.x, 2.0*camera.inv_screen_size.y), model_position.z, 1.0);
 
     var coord = vec4<f32>(pos.position.xy, 0.0, 1.0);

--- a/renderer/src/shaders/shape_shader.wgsl
+++ b/renderer/src/shaders/shape_shader.wgsl
@@ -24,18 +24,19 @@ struct VertexInput {
     @builtin(instance_index) instance_index : u32,
     @location(0) position: vec2<f32>,
     @location(1) normal: vec2<f32>,
-    @location(2) uv_dist: vec3<f32>,
-    @location(3) style_index: u32,
+    @location(2) uv: vec2<f32>,
+    @location(3) dist: u32,
+    @location(4) style_index: u32,
 }
 
 struct InstanceInput {
-    @location(4) position: vec3<f32>,
-    @location(5) color_alpha: f32,
-    @location(6) model_matrix_0: vec4<f32>,
-    @location(7) model_matrix_1: vec4<f32>,
-    @location(8) model_matrix_2: vec4<f32>,
-    @location(9) model_matrix_3: vec4<f32>,
-    @location(10) bbox: vec4<f32>,
+    @location(5) position: vec3<f32>,
+    @location(6) color_alpha: f32,
+    @location(7) model_matrix_0: vec4<f32>,
+    @location(8) model_matrix_1: vec4<f32>,
+    @location(9) model_matrix_2: vec4<f32>,
+    @location(10) model_matrix_3: vec4<f32>,
+    @location(11) bbox: vec4<f32>
 }
 
 struct VertexOutput {
@@ -90,7 +91,7 @@ fn vs_main(
 
     out.vertex_pos_xy = pointPos.xy;
     out.bbox = pos.bbox;
-    out.uv_dist = model.uv_dist;
+    out.uv_dist = vec3f(model.uv, f32(model.dist));
     out.clip_position = camera.view_proj * vec4<f32>(pointPos, 1.0);
     return out;
 }
@@ -146,7 +147,7 @@ fn vs_main_route(
     }
 
     out.vertex_pos_xy = pointPos.xy;
-    out.uv_dist = model.uv_dist;
+    out.uv_dist = vec3f(model.uv, f32(model.dist));
     out.clip_position = camera.view_proj * vec4<f32>(pointPos, 1.0);
     return out;
 }

--- a/renderer/src/svg/svg_parser.rs
+++ b/renderer/src/svg/svg_parser.rs
@@ -315,16 +315,16 @@ impl GpuPrimitive {
 
 impl VertexCtor {
     fn to_shape_vertex(&self, position: &Point, normal: &Vector) -> ShapeVertex {
-        ShapeVertex {
-            position: [
-                (position.x - self.original_size.width() / 2.0) * self.scale,
-                // Y should be flipped since mercator coords are flipped
-                (self.original_size.height() / 2.0 - position.y) * self.scale,
-            ],
-            normals: [normal.x, normal.y],
-            uv_dist: [position.x / self.original_size.width(), position.y / self.original_size.height(), 0.0],
-            style_index: self.style_index,
-        }
+        ShapeVertex::new([
+                             (position.x - self.original_size.width() / 2.0) * self.scale,
+                             // Y should be flipped since mercator coords are flipped
+                             (self.original_size.height() / 2.0 - position.y) * self.scale,
+                         ],
+                         [normal.x, normal.y],
+                         [position.x / self.original_size.width(), position.y / self.original_size.height()],
+                         0.0,
+                         self.style_index as u8,
+        )
     }
 }
 

--- a/renderer/src/text/glyph_tesselator.rs
+++ b/renderer/src/text/glyph_tesselator.rs
@@ -108,26 +108,22 @@ struct GlyphVertexConstructor {
 
 impl FillVertexConstructor<MeshVertexWithUV> for GlyphVertexConstructor {
     fn new_vertex(&mut self, vertex: FillVertex) -> MeshVertexWithUV {
-        MeshVertexWithUV {
-            position: [
-                vertex.position().x + self.offset.x,
-                vertex.position().y + self.offset.y,
-            ],
-            color: [self.color.r as f32, self.color.g as f32, self.color.b as f32],
-            uv: [0.0, 0.0],
-        }
+        MeshVertexWithUV::new([
+                                  vertex.position().x + self.offset.x,
+                                  vertex.position().y + self.offset.y,
+                              ],
+                              [self.color.r as f32, self.color.g as f32, self.color.b as f32],
+                              [0.0, 0.0])
     }
 }
 
 impl StrokeVertexConstructor<MeshVertexWithUV> for GlyphVertexConstructor {
     fn new_vertex(&mut self, vertex: lyon::tessellation::StrokeVertex) -> MeshVertexWithUV {
-        MeshVertexWithUV {
-            position: [
-                vertex.position().x + self.offset.x,
-                vertex.position().y + self.offset.y,
-            ],
-            color: [self.color.r as f32, self.color.g as f32, self.color.b as f32],
-            uv: [0.0, 0.0],
-        }
+        MeshVertexWithUV::new([
+                                  vertex.position().x + self.offset.x,
+                                  vertex.position().y + self.offset.y,
+                              ],
+                              [self.color.r as f32, self.color.g as f32, self.color.b as f32],
+                              [0.0, 0.0])
     }
 }

--- a/renderer/src/text/glyph_tesselator.rs
+++ b/renderer/src/text/glyph_tesselator.rs
@@ -1,4 +1,3 @@
-use crate::draw_commands::MeshVertex;
 use crate::vertex_attrs::MeshVertexWithUV;
 use glam::Vec2;
 use lyon::lyon_tessellation::{BuffersBuilder, FillOptions, FillTessellator, FillVertex, FillVertexConstructor, LineCap, LineJoin, StrokeVertexConstructor, VertexBuffers};
@@ -110,14 +109,10 @@ struct GlyphVertexConstructor {
 impl FillVertexConstructor<MeshVertexWithUV> for GlyphVertexConstructor {
     fn new_vertex(&mut self, vertex: FillVertex) -> MeshVertexWithUV {
         MeshVertexWithUV {
-            mesh_vertex: MeshVertex {
-                position: [
-                    vertex.position().x + self.offset.x,
-                    vertex.position().y + self.offset.y,
-                    0.0,
-                ],
-                normals: [0.0, 0.0, 0.0],
-            },
+            position: [
+                vertex.position().x + self.offset.x,
+                vertex.position().y + self.offset.y,
+            ],
             color: [self.color.r as f32, self.color.g as f32, self.color.b as f32],
             uv: [0.0, 0.0],
         }
@@ -127,14 +122,10 @@ impl FillVertexConstructor<MeshVertexWithUV> for GlyphVertexConstructor {
 impl StrokeVertexConstructor<MeshVertexWithUV> for GlyphVertexConstructor {
     fn new_vertex(&mut self, vertex: lyon::tessellation::StrokeVertex) -> MeshVertexWithUV {
         MeshVertexWithUV {
-            mesh_vertex: MeshVertex {
-                position: [
-                    vertex.position().x + self.offset.x,
-                    vertex.position().y + self.offset.y,
-                    0.0,
-                ],
-                normals: [0.0, 0.0, 0.0],
-            },
+            position: [
+                vertex.position().x + self.offset.x,
+                vertex.position().y + self.offset.y,
+            ],
             color: [self.color.r as f32, self.color.g as f32, self.color.b as f32],
             uv: [0.0, 0.0],
         }

--- a/renderer/src/vertex_attrs.rs
+++ b/renderer/src/vertex_attrs.rs
@@ -27,14 +27,14 @@ pub struct ShapeVertex {
 #[repr(C)]
 #[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
 pub struct MeshVertexWithUV {
-    pub mesh_vertex: MeshVertex,
+    pub position: [f32; 2],
     pub color: [f32; 3],
     pub uv: [f32; 2],
 }
 
 impl VertexAttrib for MeshVertexWithUV {
     const ATTRIBUTES: &[VertexAttribute] =
-        &wgpu::vertex_attr_array![0 => Float32x3, 1 => Float32x3, 2=> Float32x3, 3 => Float32x2];
+        &wgpu::vertex_attr_array![0 => Float32x2, 1 => Float32x3, 2 => Float32x2];
 
     const STEP_MODE: VertexStepMode = wgpu::VertexStepMode::Vertex;
 }

--- a/renderer/src/vertex_attrs.rs
+++ b/renderer/src/vertex_attrs.rs
@@ -1,4 +1,6 @@
 use std::mem;
+use glam::{Vec2, Vec4};
+use num::traits::float::FloatCore;
 use wgpu::{BufferAddress, VertexAttribute, VertexStepMode};
 use crate::draw_commands::MeshVertex;
 
@@ -19,22 +21,51 @@ pub trait VertexAttrib: Sized {
 #[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
 pub struct ShapeVertex {
     pub position: [f32; 2],
-    pub normals: [f32; 2],
-    pub uv_dist: [f32; 3],
-    pub style_index: u32,
+    pub normals: [i16; 2],
+    pub uv: [u16; 2],
+    pub dist: u16,
+    pub style_index: u8,
+    _pad: u8,
+}
+
+impl ShapeVertex {
+    pub fn new(position: [f32; 2], normals: [f32; 2], uv: [f32; 2], dist: f32, style_index: u8) -> Self {
+        let normals = (Vec2::new(normals[0], normals[1]) * 32767.0).round().as_i16vec2().into();
+        let uv = (Vec2::new(uv[0], uv[1]) * 65535.0).round().as_u16vec2().into();
+        ShapeVertex {
+            position,
+            normals,
+            uv,
+            dist: dist.round() as u16,
+            style_index,
+            _pad: 0,
+        }
+    }
 }
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
 pub struct MeshVertexWithUV {
     pub position: [f32; 2],
-    pub color: [f32; 3],
-    pub uv: [f32; 2],
+    pub color: [u8; 4],
+    pub uv: [u16; 2],
+}
+
+impl MeshVertexWithUV {
+    pub fn new(position: [f32; 2], color: [f32; 3], uv: [f32; 2]) -> Self {
+        let color = (Vec4::new(color[0], color[1], color[2], 1.0) * 255.0).round().as_u8vec4().into();
+        let uv = (Vec2::new(uv[0], uv[1]) * 65535.0).round().as_u16vec2().into();
+        Self {
+            position,
+            color,
+            uv,
+        }
+    }
 }
 
 impl VertexAttrib for MeshVertexWithUV {
     const ATTRIBUTES: &[VertexAttribute] =
-        &wgpu::vertex_attr_array![0 => Float32x2, 1 => Float32x3, 2 => Float32x2];
+        &wgpu::vertex_attr_array![0 => Float32x2, 1 => Unorm8x4, 2 => Unorm16x2];
 
     const STEP_MODE: VertexStepMode = wgpu::VertexStepMode::Vertex;
 }
@@ -42,7 +73,7 @@ impl VertexAttrib for MeshVertexWithUV {
 
 impl VertexAttrib for ShapeVertex {
     const ATTRIBUTES: &[VertexAttribute] =
-        &wgpu::vertex_attr_array![0 => Float32x2, 1 => Float32x2, 2 => Float32x3, 3 => Uint32];
+        &wgpu::vertex_attr_array![0 => Float32x2, 1 => Snorm16x2, 2 => Unorm16x2, 3 => Uint16, 4 => Uint8];
 
     const STEP_MODE: VertexStepMode = wgpu::VertexStepMode::Vertex;
 }
@@ -85,13 +116,13 @@ pub struct ShapeInstanceInput {
 }
 impl VertexAttrib for ShapeInstanceInput {
     const ATTRIBUTES: &[VertexAttribute] = &wgpu::vertex_attr_array![
-        4 => Float32x3,
-        5 => Float32,
-        6 => Float32x4,
+        5 => Float32x3,
+        6 => Float32,
         7 => Float32x4,
         8 => Float32x4,
         9 => Float32x4,
         10 => Float32x4,
+        11 => Float32x4,
     ];
 
     const STEP_MODE: VertexStepMode = wgpu::VertexStepMode::Instance;


### PR DESCRIPTION
1) Speed up(up to 20%!) MSAA by discarding output texture data!
2) Check fully (un)shadowed areas in Castano implementation
3) Remove unused data in screen mesh vertex structure
4) Better vertex struck packing