### PR TITLE
Optimize the shadow map by using a stencil filter.

### DIFF
--- a/renderer/src/canvas_api.rs
+++ b/renderer/src/canvas_api.rs
@@ -10,7 +10,7 @@ use crate::styles::style_id::StyleId;
 use crate::styles::style_store::StyleStore;
 use crate::svg::svg_parser::svg_parse;
 use crate::vertex_attrs::ShapeVertex;
-use glam::{DVec3, Vec2, Vec3};
+use glam::{DVec3, Vec3};
 use lyon::geom::euclid::{point2, Box2D};
 use lyon::lyon_tessellation::{
     BuffersBuilder, FillOptions, FillTessellator, FillVertex, StrokeOptions, StrokeTessellator,

--- a/renderer/src/mesh_layers/general_mesh_layer.rs
+++ b/renderer/src/mesh_layers/general_mesh_layer.rs
@@ -7,8 +7,8 @@ use crate::mesh_layers::BaseMeshLayer;
 use crate::modifier::render_modifier::SpatialData;
 use crate::pipelines::RenderPipeline;
 use std::mem;
-use wgpu::{CommandEncoder, ComputePassDescriptor, Face, RenderPass};
 use wgpu::TextureFormat::Rgba16Float;
+use wgpu::{CommandEncoder, ComputePassDescriptor, Face, RenderPass};
 
 pub(crate) struct GeneralMeshLayer<P: RenderPipeline> {
     render_pipeline: P,
@@ -17,10 +17,11 @@ pub(crate) struct GeneralMeshLayer<P: RenderPipeline> {
     shadow_pipeline: Option<wgpu::RenderPipeline>,
     render_data_holder: RenderDataHolder<PositionedMesh<P::InstanceInputType>>,
     pub disable_skip_mesh_feature: bool,
+    write_to_stencil: bool,
 }
 
 impl<P: RenderPipeline> GeneralMeshLayer<P> {
-    pub fn new(render_pipeline: P) -> Self {
+    pub fn new(render_pipeline: P, write_to_stencil: bool) -> Self {
         GeneralMeshLayer {
             render_pipeline,
             pipeline: None,
@@ -28,6 +29,7 @@ impl<P: RenderPipeline> GeneralMeshLayer<P> {
             shadow_pipeline: None,
             render_data_holder: RenderDataHolder::new(),
             disable_skip_mesh_feature: false,
+            write_to_stencil
         }
     }
     pub fn add(
@@ -78,9 +80,22 @@ impl<P: RenderPipeline> GeneralMeshLayer<P> {
 
 impl<P: RenderPipeline> BaseMeshLayer for GeneralMeshLayer<P> {
     fn prepare(&mut self, global_context: &GlobalContext) {
-        let descriptor = self.render_pipeline.prepare(global_context);
+        let mut descriptor = self.render_pipeline.prepare(global_context);
         let mut g_buffer_descriptor = descriptor.clone();
         let mut shadow_descriptor = descriptor.clone();
+        if self.write_to_stencil {
+            descriptor.depth_stencil.as_mut().unwrap().stencil = wgpu::StencilState {
+                front: wgpu::StencilFaceState {
+                    compare: wgpu::CompareFunction::Always,
+                    fail_op: wgpu::StencilOperation::Keep,
+                    depth_fail_op: wgpu::StencilOperation::Keep,
+                    pass_op: wgpu::StencilOperation::Replace,
+                },
+                back: wgpu::StencilFaceState::default(),
+                read_mask: 0xFF,
+                write_mask: 0xFF,
+            };
+        }
 
         self.pipeline = Some(descriptor.to_render_pipeline(global_context.device()));
 
@@ -144,6 +159,9 @@ impl<P: RenderPipeline> BaseMeshLayer for GeneralMeshLayer<P> {
                 render_pass.set_pipeline(self.shadow_pipeline.as_ref().unwrap());
             } else {
                 render_pass.set_pipeline(render_pipeline);
+                if self.write_to_stencil {
+                    render_pass.set_stencil_reference(1);
+                }
             }
 
             self.render_pipeline.render(render_pass, global_context);

--- a/renderer/src/mesh_layers/layers.rs
+++ b/renderer/src/mesh_layers/layers.rs
@@ -47,7 +47,8 @@ impl Layers {
     ) -> Layers {
         let feature_layers = FeatureLayers::new(world_shapes_feature_tags,
                                                 |tag| {
-                                                    GeneralMeshLayer::new(ShapePipeline::new(global_context, tag.vertex_shader, tag.indirect))
+                                                    GeneralMeshLayer::new(ShapePipeline::new(global_context, tag.vertex_shader, tag.indirect),
+                                                    false)
                                                 });
         let text_feature_layers = FeatureLayers::new(vec![
             NameLayerTag(WORLD_TEXT_LAYER),
@@ -66,8 +67,8 @@ impl Layers {
 
         Layers {
             feature_layers,
-            mesh_layer: GeneralMeshLayer::new(MeshPipeline::new(global_context)),
-            shape_layer: GeneralMeshLayer::new(ShapePipeline::new(global_context, None, false)),
+            mesh_layer: GeneralMeshLayer::new(MeshPipeline::new(global_context), true),
+            shape_layer: GeneralMeshLayer::new(ShapePipeline::new(global_context, None, false), false),
             screen_shape_layer: ScreenShapeLayer::new(ShapePipeline::new(global_context, Some("vs_main_screen"), false),
                                                       global_context),
             shadow_map_layer: OrthoMeshLayer::new(ScreenMeshPipeline::new(global_context, TextureInfo {
@@ -75,20 +76,20 @@ impl Layers {
                 filterable: false,
                 vs_shader: Some("vs_main_sm"),
                 fs_shader: "fs_main_sm",
-            }), true, false),
+            }), true, false, true),
             text_feature_layers,
             preview_mesh_layer: OrthoMeshLayer::new(ScreenMeshPipeline::new(global_context, TextureInfo {
                 use_texture: true,
                 filterable: true,
                 vs_shader: None,
                 fs_shader: "fs_main_textured",
-            }), false, true),
+            }), false, true, false),
             post_process_layer: OrthoMeshLayer::new(ScreenMeshPipeline::new(global_context, TextureInfo {
                 use_texture: true,
                 filterable: true,
                 vs_shader: None,
                 fs_shader: "fs_main_tex_storage",
-            }), true, false),
+            }), true, false, false),
         }
     }
 
@@ -132,11 +133,13 @@ impl BaseMeshLayer for Layers {
             self.shape_layer.render(render_pass, global_context);
         }
         if !global_context.is_preview_render {
+            self.mesh_layer.render(render_pass, global_context);
+
             let not_shadow_or_g_buf = !global_context.is_g_buffer_render && !global_context.is_shadow_render;
             if unsafe { SHADOWS_ENABLED } && not_shadow_or_g_buf {
                 self.shadow_map_layer.render(render_pass, global_context);
             }
-            self.mesh_layer.render(render_pass, global_context);
+
             if unsafe { SSAO_ENABLED } && not_shadow_or_g_buf {
                 self.post_process_layer.render(render_pass, global_context);
             }

--- a/renderer/src/mesh_layers/ortho_mesh_layer.rs
+++ b/renderer/src/mesh_layers/ortho_mesh_layer.rs
@@ -6,7 +6,7 @@ use crate::mesh_layers::BaseMeshLayer;
 use crate::pipelines::{RenderPipeline, WithTexture};
 use crate::vertex_attrs::TextInstanceInput;
 use log::error;
-use wgpu::{BindGroup, CommandEncoder, RenderPass, TextureFormat, TextureUsages, TextureView};
+use wgpu::{BindGroup, CommandEncoder, RenderPass, StencilFaceState, TextureFormat, TextureUsages, TextureView};
 
 #[repr(u8)]
 #[derive(Debug, Copy, Clone)]
@@ -25,12 +25,14 @@ pub struct OrthoMeshLayer<P: RenderPipeline + WithTexture> {
     full_screen_mesh: bool,
     is_bottom_right: bool,
     texture_type: TextureType,
+    read_stencil: bool
 }
 
 impl<P: RenderPipeline + WithTexture> OrthoMeshLayer<P> {
     pub fn new(render_pipeline: P,
                full_screen_mesh: bool,
-               is_bottom_right: bool) -> Self {
+               is_bottom_right: bool,
+               read_stencil: bool) -> Self {
         Self {
             render_pipeline,
             pipeline: None,
@@ -40,6 +42,7 @@ impl<P: RenderPipeline + WithTexture> OrthoMeshLayer<P> {
             full_screen_mesh,
             is_bottom_right,
             texture_type: TextureType::GeneralRgba,
+            read_stencil
         }
     }
 
@@ -120,7 +123,21 @@ impl<P: RenderPipeline + WithTexture> OrthoMeshLayer<P> {
 
 impl<P: RenderPipeline + WithTexture> BaseMeshLayer for OrthoMeshLayer<P> {
     fn prepare(&mut self, global_context: &GlobalContext) {
-        let descriptor = self.render_pipeline.prepare(global_context);
+        let mut descriptor = self.render_pipeline.prepare(global_context);
+        if self.read_stencil {
+            descriptor.depth_stencil.as_mut().unwrap().stencil = wgpu::StencilState {
+                front: StencilFaceState::IGNORE,
+                back: wgpu::StencilFaceState {
+                    compare: wgpu::CompareFunction::NotEqual,
+                    fail_op: wgpu::StencilOperation::Keep,
+                    depth_fail_op: wgpu::StencilOperation::Keep,
+                    pass_op: wgpu::StencilOperation::Keep,
+                },
+                read_mask: 0xFF,
+                write_mask: 0x00,
+            };
+        }
+
         self.pipeline = Some(descriptor.to_render_pipeline(global_context.device()));
     }
 
@@ -135,6 +152,9 @@ impl<P: RenderPipeline + WithTexture> BaseMeshLayer for OrthoMeshLayer<P> {
         }
         if let (Some(render_pipeline), Some(mesh)) = (self.pipeline.as_ref(), self.mesh.as_ref()) {
             render_pass.set_pipeline(render_pipeline);
+            if self.read_stencil {
+                render_pass.set_stencil_reference(1);
+            }
 
             self.render_pipeline.render(render_pass, global_context);
 

--- a/renderer/src/pass_nodes/main_pass_node.rs
+++ b/renderer/src/pass_nodes/main_pass_node.rs
@@ -201,7 +201,7 @@ impl MainPassNode {
             non_msaa_texture_view_normals,
             depth_texture_view: create_depth_texture(size,
                                                      SAMPLE_COUNT,
-                                                     TextureFormat::Depth24Plus,
+                                                     TextureFormat::Depth24PlusStencil8,
                                                      global_context.device()),
             non_msaa_depth_texture_view,
             ssao_bind_group,
@@ -278,7 +278,10 @@ impl PassNode for MainPassNode {
                 load: wgpu::LoadOp::Clear(1.0),
                 store: wgpu::StoreOp::Store,
             }),
-            stencil_ops: None,
+            stencil_ops: Some(wgpu::Operations {
+                load: wgpu::LoadOp::Clear(0),
+                store: wgpu::StoreOp::Store,
+            }),
         };
 
         if unsafe { SSAO_ENABLED } {

--- a/renderer/src/pipelines/mesh_pipeline.rs
+++ b/renderer/src/pipelines/mesh_pipeline.rs
@@ -199,7 +199,7 @@ impl RenderPipeline for MeshPipeline {
             },
             depth_stencil: Some({
                 DepthStencilState {
-                    format: TextureFormat::Depth24Plus,
+                    format: TextureFormat::Depth24PlusStencil8,
                     depth_write_enabled: Some(true),
                     depth_compare: Some(CompareFunction::Less),
                     stencil: Default::default(),

--- a/renderer/src/vertex_attrs.rs
+++ b/renderer/src/vertex_attrs.rs
@@ -1,6 +1,5 @@
 use std::mem;
 use glam::{Vec2, Vec4};
-use num::traits::float::FloatCore;
 use wgpu::{BufferAddress, VertexAttribute, VertexStepMode};
 use crate::draw_commands::MeshVertex;
 


### PR DESCRIPTION
Check the stencil(from buildings) before rendering shadow on the "ground".
It offers a speed up around 5-10%