### PR TITLE
Improve 2D - 3D transition

### DIFF
--- a/map/src/lib.rs
+++ b/map/src/lib.rs
@@ -523,7 +523,7 @@ impl<T: TilesProvider> ShashlikMap<T> {
     }
 
     pub fn load_kml_path(&self, path_buf: PathBuf) {
-        println!("Loading KML from {:?}", path_buf);
+        println!("Loading KMdL from {:?}", path_buf);
         let kml_group = KmlGroup::new(path_buf, self.create_location_coord_converter());
 
         self.renderer.api.add_render_group(

--- a/map/src/tiles/shashlik_tiles_provider_v0.rs
+++ b/map/src/tiles/shashlik_tiles_provider_v0.rs
@@ -122,7 +122,7 @@ impl<S: TileSource, FP: FeatureProcessor + 'static> ShashlikTilesProviderV0<S, F
                     let is_visible = !cfg!(target_os = "linux")
                         || zoom_level == 0
                         // reduce amount of buildings for linux
-                        || (zoom_level == 1 && is_building && poly.unsigned_area() >= 3.0);
+                        || (zoom_level == 1 && is_building && poly.unsigned_area() >= 2.0);
 
                     let is_visible = !is_building || is_visible;
 

--- a/renderer/src/global_context.rs
+++ b/renderer/src/global_context.rs
@@ -7,7 +7,7 @@ use crate::RendererUpdateData;
 use wgpu::util::DeviceExt;
 use wgpu::{BindGroup, BindGroupLayout, Device, TextureFormat, TextureUsages, TextureView};
 use wgpu_canvas::wgpu_canvas::WgpuCanvas;
-use wgpu_canvas::SHADOWS_TEX_SIZE;
+use wgpu_canvas::{SHADOWS_ENABLED, SHADOWS_TEX_SIZE};
 
 pub struct GlobalContext {
     pub canvas: Box<dyn WgpuCanvas>,
@@ -130,5 +130,9 @@ impl GlobalContext {
     }
     pub fn device(&self) -> &wgpu::Device {
         self.canvas.device()
+    }
+
+    pub fn is_shadow_mapping_enabled(&self) -> bool {
+         (self.view_projection.scale_2d_3d > 0.0) && unsafe { SHADOWS_ENABLED }
     }
 }

--- a/renderer/src/mesh_layers/layers.rs
+++ b/renderer/src/mesh_layers/layers.rs
@@ -1,4 +1,5 @@
 use crate::global_context::GlobalContext;
+use crate::mesh_layers::feature_layers::{FeatureLayerTag, FeatureLayers, NameLayerTag};
 use crate::mesh_layers::general_mesh_layer::GeneralMeshLayer;
 use crate::mesh_layers::ortho_mesh_layer::OrthoMeshLayer;
 use crate::mesh_layers::screen_shape_layer::ScreenShapeLayer;
@@ -9,8 +10,7 @@ use crate::pipelines::screen_mesh_pipeline::{ScreenMeshPipeline, TextureInfo};
 use crate::pipelines::shape_pipeline::ShapePipeline;
 use rustybuzz::ttf_parser;
 use wgpu::{CommandEncoder, RenderPass};
-use wgpu_canvas::{PREVIEW_TYPE, SHADOWS_ENABLED, SSAO_ENABLED};
-use crate::mesh_layers::feature_layers::{FeatureLayerTag, FeatureLayers, NameLayerTag};
+use wgpu_canvas::{PREVIEW_TYPE, SSAO_ENABLED};
 
 pub(crate) const WORLD_TEXT_LAYER: &'static str = "world_text_layer";
 pub(crate) const SCREEN_TEXT_LAYER: &'static str = "screen_text_layer";
@@ -136,7 +136,7 @@ impl BaseMeshLayer for Layers {
             self.mesh_layer.render(render_pass, global_context);
 
             let not_shadow_or_g_buf = !global_context.is_g_buffer_render && !global_context.is_shadow_render;
-            if unsafe { SHADOWS_ENABLED } && not_shadow_or_g_buf {
+            if global_context.is_shadow_mapping_enabled() && not_shadow_or_g_buf {
                 self.shadow_map_layer.render(render_pass, global_context);
             }
 

--- a/renderer/src/pass_nodes/shadow_pre_pass.rs
+++ b/renderer/src/pass_nodes/shadow_pre_pass.rs
@@ -1,9 +1,8 @@
 use crate::global_context::GlobalContext;
-use crate::mesh_layers::BaseMeshLayer;
 use crate::mesh_layers::layers::Layers;
+use crate::mesh_layers::BaseMeshLayer;
 use crate::pass_nodes::PassNode;
 use wgpu::{CommandEncoder, TextureView};
-use wgpu_canvas::SHADOWS_ENABLED;
 
 pub(crate) struct ShadowPrepass {}
 
@@ -29,7 +28,7 @@ impl PassNode for ShadowPrepass {
         layers: &mut Layers,
         global_context: &mut GlobalContext,
     ) {
-        if !unsafe { SHADOWS_ENABLED } {
+        if !global_context.is_shadow_mapping_enabled() {
             return;
         }
         let depth_attachment = wgpu::RenderPassDepthStencilAttachment {

--- a/renderer/src/pipelines/mesh_pipeline.rs
+++ b/renderer/src/pipelines/mesh_pipeline.rs
@@ -6,7 +6,6 @@ use crate::vertex_attrs::{GeneralInstanceInput, VertexAttrib};
 use std::borrow::Cow;
 use wesl::include_wesl;
 use wgpu::{BindGroup, BindGroupLayout, BlendState, CompareFunction, ComputePass, DepthStencilState, Face, RenderPass, SamplerDescriptor, ShaderModuleDescriptor, ShaderSource, TextureFormat, TextureUsages};
-use wgpu_canvas::SHADOWS_ENABLED;
 
 pub struct MeshPipeline {
     pub bind_group_layout: BindGroupLayout,
@@ -138,7 +137,7 @@ impl RenderPipeline for MeshPipeline {
 
     fn render(&mut self, render_pass: &mut RenderPass, global_context: &GlobalContext) {
         let mut mask = global_context.is_shadow_render as u32;
-        if unsafe { SHADOWS_ENABLED } {
+        if global_context.is_shadow_mapping_enabled() {
             mask |= 2;
         }
         render_pass.set_immediates(
@@ -147,7 +146,8 @@ impl RenderPipeline for MeshPipeline {
         );
         render_pass.set_bind_group(0, &self.bind_group, &[]);
 
-        if unsafe { !SHADOWS_ENABLED } ||
+
+        if !global_context.is_shadow_mapping_enabled() ||
             global_context.is_shadow_render ||
             global_context.is_preview_render ||
             global_context.is_g_buffer_render {

--- a/renderer/src/view_projection.rs
+++ b/renderer/src/view_projection.rs
@@ -43,6 +43,7 @@ pub(crate) struct ViewProjUniform {
 #[derive(Clone)]
 pub struct ViewProjection {
     uniform: ViewProjUniform,
+    pub scale_2d_3d: f32,
     pub cs_offset: DVec3,
     pub screen_size: (f64, f64),
     inv_view_proj_matrix: DMat4,
@@ -82,6 +83,7 @@ impl ViewProjection {
                 p2_scale: 1.0,
                 scale_2d_3d: 1.0,
             },
+            scale_2d_3d: 0.0,
             screen_size: (0.0, 0.0),
             cs_offset: DVec3::new(0.0, 0.0, 0.0),
             inv_view_proj_matrix: DMat4::IDENTITY,
@@ -120,6 +122,7 @@ impl ViewProjection {
             .as_mat4()
             .to_cols_array_2d();
         self.uniform.scale = data.scale;
+        self.scale_2d_3d = data.scale_2d_3d;
         self.uniform.p2_scale = self.p2_scale(data.scale);
         self.uniform.scale_2d_3d = data.scale_2d_3d;
         self.cs_offset = data.cs_offset;


### PR DESCRIPTION
Disable shadow mapping in the right moment to have a smoother transition between 2D and 3D