### PR TITLE
MVT Tiles. Refactor tile schema parser

### DIFF
--- a/map/src/tiles/mvt/mod.rs
+++ b/map/src/tiles/mvt/mod.rs
@@ -1,5 +1,6 @@
 pub mod mvt_tile_store;
 mod mvt_parser;
+mod mvt_scheme_parser;
 
 
 

--- a/map/src/tiles/mvt/mvt_parser.rs
+++ b/map/src/tiles/mvt/mvt_parser.rs
@@ -9,14 +9,13 @@ use osm::map::{MapGeomObject, MapGeometry};
 use osm::tiles::TileKey;
 
 pub struct MvtParser {
-    mvt_s: MvtSchemeParser,
+    schema_parser: MvtSchemeParser,
 }
 
-// TODO This is WIP and requires reworking. So far just a temporary PoC implementation
 impl MvtParser {
     pub fn new() -> Self {
         Self {
-            mvt_s: MvtSchemeParser::new_map_tiler_v4(),
+            schema_parser: MvtSchemeParser::new_map_tiler_v4(),
         }
     }
     fn get_all_lines(geometry: Geometry<i32>) -> Vec<LineString<i32>> {
@@ -36,7 +35,7 @@ impl MvtParser {
     ) -> MvtResult<Vec<(MapGeomObject, MapGeometry<f32>)>> {
         let reader = MvtReaderRef::new(bytes)?;
         let koef = 512.0f32 / 4096.0;
-        let mut result = self.mvt_s.parse(reader.layers(), |feature| {
+        let mut result = self.schema_parser.parse(reader.layers(), |feature| {
             let mut res = vec![];
             let geom_type = feature.geom_type();
             let geometry = feature.geometry();

--- a/map/src/tiles/mvt/mvt_parser.rs
+++ b/map/src/tiles/mvt/mvt_parser.rs
@@ -1,7 +1,7 @@
-use std::fmt::format;
+use crate::tiles::mvt::mvt_scheme_parser::MvtSchemeParser;
 use crate::MAX_ZOOM_LEVEL;
 use fast_mvt::proto::GeomType;
-use fast_mvt::{MvtGeometry, MvtReaderRef, MvtResult, MvtValueRef};
+use fast_mvt::{MvtGeometry, MvtReaderRef, MvtResult, MvtValue, MvtValueRef};
 use geo::{CoordsIter, MapCoords};
 use geo_types::{coord, Geometry, LineString, Polygon};
 use osm::map::{
@@ -10,10 +10,17 @@ use osm::map::{
 };
 use osm::tiles::TileKey;
 
-pub struct MvtParser;
+pub struct MvtParser {
+    mvt_s: MvtSchemeParser
+}
 
 // TODO This is WIP and requires reworking. So far just a temporary PoC implementation
 impl MvtParser {
+    pub fn new() -> Self {
+        Self {
+            mvt_s: MvtSchemeParser::new_map_tiler_v4()
+        }
+    }
     fn get_all_lines(geometry: Geometry<i32>) -> Vec<LineString<i32>> {
         match geometry {
             Geometry::LineString(line_string) => {
@@ -32,6 +39,47 @@ impl MvtParser {
                 Vec::new()
             }
         }
+    }
+
+    pub fn read_mvt_tile2(
+        &mut self,
+        bytes: &[u8],
+        tile_key: &TileKey,
+    ) -> MvtResult<Vec<(MapGeomObject, MapGeometry<f32>)>> {
+        let reader = MvtReaderRef::new(bytes)?;
+        let kk = 512.0f32 / 4096.0;
+        let mut result = self.mvt_s.parse(reader.layers(), |feature| {
+            let mut res = vec![];
+            let geom_type = feature.geom_type();
+            let geometry = feature.geometry();
+
+            if let Some(geom_type) = geom_type && geometry.is_ok() {
+                if geom_type == GeomType::LINESTRING {
+                    for line in Self::get_all_lines(feature.geometry().unwrap()) {
+                        let ls: LineString<f32> = line
+                            .coords_iter()
+                            .map(|coord| {
+                                coord! { x: coord.x as f32 * kk, y: coord.y as f32 * kk}
+                            })
+                            .collect();
+
+                        res.push(MapGeometry::Line(ls));
+                    }
+                } else if geom_type == GeomType::POLYGON {}
+            }
+            res
+        });
+
+        result.sort_by(|(a, _), (b, _)| a.cmp(b));
+        let fixed = result
+            .into_iter()
+            .map(|(geom, obj)| {
+                let obj_fixed = Self::convert_and_restore_data(&obj, tile_key);
+                (geom, obj_fixed)
+            })
+            .collect();
+
+        Ok(fixed)
     }
 
     pub fn read_mvt_tile(
@@ -270,9 +318,46 @@ impl MvtParser {
     }
 }
 
-struct LocalMvtValue<'a>(MvtValueRef<'a>);
+pub(crate) struct LocalMvtValue2(pub MvtValue);
+
+impl From<LocalMvtValue2> for i64 {
+    fn from(value: LocalMvtValue2) -> Self {
+        match value.0 {
+            MvtValue::SInt(value) => value,
+            _ => panic!("Unexpected MvtValueRef"),
+        }
+    }
+}
+
+impl From<LocalMvtValue2> for String {
+    fn from(value: LocalMvtValue2) -> Self {
+        match value.0 {
+            MvtValue::String(value) => value,
+            _ => panic!("Unexpected MvtValueRef"),
+        }
+    }
+}
+
+impl From<LocalMvtValue2> for bool {
+    fn from(value: LocalMvtValue2) -> Self {
+        match value.0 {
+            MvtValue::Bool(value) => value,
+            _ => panic!("Unexpected MvtValueRef"),
+        }
+    }
+}
+
+pub(crate) struct LocalMvtValue<'a>(pub MvtValueRef<'a>);
 impl From<LocalMvtValue<'_>> for i64 {
     fn from(value: LocalMvtValue<'_>) -> Self {
+        match value.0 {
+            MvtValueRef::SInt(value) => value,
+            _ => panic!("Unexpected MvtValueRef"),
+        }
+    }
+}
+impl <'a> From<&'a LocalMvtValue<'a>> for i64 {
+    fn from(value: &LocalMvtValue<'a>) -> Self {
         match value.0 {
             MvtValueRef::SInt(value) => value,
             _ => panic!("Unexpected MvtValueRef"),

--- a/map/src/tiles/mvt/mvt_parser.rs
+++ b/map/src/tiles/mvt/mvt_parser.rs
@@ -1,3 +1,4 @@
+use std::fmt::format;
 use crate::MAX_ZOOM_LEVEL;
 use fast_mvt::proto::GeomType;
 use fast_mvt::{MvtGeometry, MvtReaderRef, MvtResult, MvtValueRef};
@@ -48,40 +49,46 @@ impl MvtParser {
                         && geom_type == GeomType::LINESTRING
                     {
                         let mut layer: i64 = 0;
-                        let mut highway_kind: Option<HighwayKind> = None;
+                        let mut highway_kind_name: Option<&str> = None;
+                        let mut brunnel = false;
+                        let mut ramp = false;
                         for property in feature.properties() {
                             let (key, value) = property?;
                             if key == "layer" {
                                 layer = LocalMvtValue(value).into();
                             } else if key == "class" {
                                 let road_class: String = LocalMvtValue(value).into();
-                                highway_kind = match road_class.as_str() {
-                                    "motorway" => Some(HighwayKind::Motorway),
-                                    "primary" => Some(HighwayKind::Primary),
-                                    "secondary" => Some(HighwayKind::Secondary),
-                                    "tertiary" => Some(HighwayKind::Tertiary),
-                                    "unclassified" => Some(HighwayKind::Unclassified),
-                                    "residential" => Some(HighwayKind::Residential),
-                                    "minor" => Some(HighwayKind::Residential),
-                                    // "motorwaylink" => Some(HighwayKind::MotorwayLink),
-                                    // "trunklink" => Some(HighwayKind::TrunkLink),
-                                    // "primarylink" => Some(HighwayKind::PrimaryLink),
-                                    // "secondarylink" => Some(HighwayKind::SecondaryLink),
-                                    // "tertiarylink" => Some(HighwayKind::TertiaryLink),
-                                    "service" => Some(HighwayKind::Service),
-                                    "trunk" => Some(HighwayKind::Trunk),
+                                highway_kind_name = match road_class.as_str() {
+                                    "motorway" => Some("motorway"),
+                                    "primary" => Some("primary"),
+                                    "secondary" => Some("secondary"),
+                                    "tertiary" => Some("tertiary"),
+                                    "unclassified" => Some("unclassified"),
+                                    "residential" => Some("residential"),
+                                    "minor" => Some("residential"),
+                                    "service" => Some("service"),
+                                    "trunk" => Some("trunk"),
                                     _ => None,
                                 };
+                            } else if key == "brunnel" {
+                                brunnel = true;
+                            } else if key == "ramp" {
+                                ramp = true;
                             }
                         }
 
-                        if let Some(highway_kind) = highway_kind {
+                        if let Some(highway_kind_name) = highway_kind_name {
+                            let mut bb = highway_kind_name.to_string();
+                            if ramp {
+                                bb = format!("{highway_kind_name}_link");
+                            }
+                            let highway_kind = HighwayKind::from_descr(bb.as_str()).unwrap();
                             let kk = 512.0f32 / 4096.0;
                             let geom_object = MapGeomObject {
                                 id: -1,
                                 kind: MapGeomObjectKind::Way(WayInfo {
                                     line_kind: LineKind::Highway { kind: highway_kind },
-                                    layer: layer as i32,
+                                    layer: if brunnel { layer as i32 } else { 0 },
                                     layer_kind: LayerKind::None,
                                     name_en: None,
                                 }),
@@ -229,6 +236,8 @@ impl MvtParser {
                 }
             }
         }
+
+        res.sort_by(|(a, _), (b, _)| a.cmp(b));
 
         let fixed = res
             .into_iter()

--- a/map/src/tiles/mvt/mvt_parser.rs
+++ b/map/src/tiles/mvt/mvt_parser.rs
@@ -1,10 +1,9 @@
-use crate::MAX_ZOOM_LEVEL;
 use crate::tiles::mvt::mvt_scheme_parser::MvtSchemeParser;
+use crate::MAX_ZOOM_LEVEL;
 use fast_mvt::proto::GeomType;
-use fast_mvt::{MvtGeometry, MvtReaderRef, MvtResult, MvtValue};
-use geo::{CoordsIter, MapCoords};
-use geo_types::{Geometry, LineString, Polygon, coord};
-use log::error;
+use fast_mvt::{MvtReaderRef, MvtResult};
+use geo::MapCoords;
+use geo_types::{Coord, Geometry, LineString, Polygon};
 use osm::map::{MapGeomObject, MapGeometry};
 use osm::tiles::TileKey;
 
@@ -28,13 +27,22 @@ impl MvtParser {
         }
     }
 
+    fn get_all_polygons(geometry: Geometry<i32>) -> Vec<Polygon<i32>> {
+        match geometry {
+            Geometry::Polygon(polygon) => {
+                vec![polygon]
+            }
+            Geometry::MultiPolygon(multi_polygon) => multi_polygon.into_iter().collect(),
+            _ => Vec::new(),
+        }
+    }
+
     pub fn read_mvt_tile(
         &self,
         bytes: &[u8],
         tile_key: &TileKey,
     ) -> MvtResult<Vec<(MapGeomObject, MapGeometry<f32>)>> {
         let reader = MvtReaderRef::new(bytes)?;
-        let koef = 512.0f32 / 4096.0;
         let mut result = self.schema_parser.parse(reader.layers(), |feature| {
             let mut res = vec![];
             let geom_type = feature.geom_type();
@@ -44,34 +52,14 @@ impl MvtParser {
                 && geometry.is_ok()
             {
                 let geometry = geometry.unwrap();
+                // TODO Add points later
                 if geom_type == GeomType::LINESTRING {
                     for line in Self::get_all_lines(geometry) {
-                        let ls: LineString<f32> = line
-                            .coords_iter()
-                            .map(|coord| {
-                                coord! { x: coord.x as f32 * koef, y: coord.y as f32 * koef}
-                            })
-                            .collect();
-
-                        res.push(MapGeometry::Line(ls));
+                        res.push(MapGeometry::Line(line));
                     }
                 } else if geom_type == GeomType::POLYGON {
-                    match geometry {
-                        MvtGeometry::Polygon(poly) => {
-                            let ls: Polygon<f32> = poly.map_coords(|coord| {
-                                coord! { x: coord.x as f32 * koef, y: coord.y as f32 * koef}
-                            });
-                            res.push(MapGeometry::Poly(ls));
-                        }
-                        MvtGeometry::MultiPolygon(polis) => {
-                            for poly in polis {
-                                let ls: Polygon<f32> = poly.map_coords(|coord| {
-                                    coord! { x: coord.x as f32 * koef, y: coord.y as f32 * koef}
-                                });
-                                res.push(MapGeometry::Poly(ls));
-                            }
-                        }
-                        _ => {}
+                    for polygon in Self::get_all_polygons(geometry) {
+                        res.push(MapGeometry::Poly(polygon));
                     }
                 }
             }
@@ -91,50 +79,23 @@ impl MvtParser {
     }
 
     fn convert_and_restore_data(
-        geometry: &MapGeometry<f32>,
+        geometry: &MapGeometry<i32>,
         tile_key: &TileKey,
     ) -> MapGeometry<f32> {
         // FIXME Zoom level handling
         let factor = 2.0f32.powf((MAX_ZOOM_LEVEL - tile_key.zoom_level) as f32);
+        let koef = 512.0f32 / 4096.0;
+        let total_multiplier = factor * koef;
+        let convert_coord = |c: &Coord<i32>| -> Coord<f32> {
+            Coord {
+                x: (c.x as f32) * total_multiplier,
+                y: (c.y as f32) * total_multiplier,
+            }
+        };
         match geometry {
-            MapGeometry::Line(line) => MapGeometry::Line(line.map_coords(|coord| coord * factor)),
-            MapGeometry::Poly(poly) => MapGeometry::Poly(poly.map_coords(|coord| coord * factor)),
-            MapGeometry::Coord(coord) => MapGeometry::Coord(*coord * factor),
-        }
-    }
-}
-
-pub(crate) struct LocalMvtValue(pub MvtValue);
-
-impl LocalMvtValue {
-    fn unexpected_type<T>(&self, expected: &str) -> Option<T> {
-        error!("Unexpected {} MvtValueRef: {:?}", expected, self.0);
-        None
-    }
-}
-impl From<LocalMvtValue> for Option<i64> {
-    fn from(value: LocalMvtValue) -> Self {
-        match value.0 {
-            MvtValue::SInt(value) => Some(value),
-            _ => value.unexpected_type("i64"),
-        }
-    }
-}
-
-impl From<LocalMvtValue> for Option<String> {
-    fn from(value: LocalMvtValue) -> Self {
-        match value.0 {
-            MvtValue::String(value) => Some(value),
-            _ => value.unexpected_type("String"),
-        }
-    }
-}
-
-impl From<LocalMvtValue> for Option<bool> {
-    fn from(value: LocalMvtValue) -> Self {
-        match value.0 {
-            MvtValue::Bool(value) => Some(value),
-            _ => value.unexpected_type("bool"),
+            MapGeometry::Line(line) => MapGeometry::Line(line.map_coords(|c| convert_coord(&c))),
+            MapGeometry::Poly(poly) => MapGeometry::Poly(poly.map_coords(|c| convert_coord(&c))),
+            MapGeometry::Coord(coord) => MapGeometry::Coord(convert_coord(coord)),
         }
     }
 }

--- a/map/src/tiles/mvt/mvt_parser.rs
+++ b/map/src/tiles/mvt/mvt_parser.rs
@@ -1,67 +1,56 @@
-use crate::tiles::mvt::mvt_scheme_parser::MvtSchemeParser;
 use crate::MAX_ZOOM_LEVEL;
+use crate::tiles::mvt::mvt_scheme_parser::MvtSchemeParser;
 use fast_mvt::proto::GeomType;
-use fast_mvt::{MvtGeometry, MvtReaderRef, MvtResult, MvtValue, MvtValueRef};
+use fast_mvt::{MvtGeometry, MvtReaderRef, MvtResult, MvtValue};
 use geo::{CoordsIter, MapCoords};
-use geo_types::{coord, Geometry, LineString, Polygon};
+use geo_types::{Geometry, LineString, Polygon, coord};
 use log::error;
-use osm::map::{
-    HighwayKind, LayerKind, LineKind, MapGeomObject, MapGeomObjectKind, MapGeometry, NatureKind,
-    WayInfo,
-};
+use osm::map::{MapGeomObject, MapGeometry};
 use osm::tiles::TileKey;
 
 pub struct MvtParser {
-    mvt_s: MvtSchemeParser
+    mvt_s: MvtSchemeParser,
 }
 
 // TODO This is WIP and requires reworking. So far just a temporary PoC implementation
 impl MvtParser {
     pub fn new() -> Self {
         Self {
-            mvt_s: MvtSchemeParser::new_map_tiler_v4()
+            mvt_s: MvtSchemeParser::new_map_tiler_v4(),
         }
     }
     fn get_all_lines(geometry: Geometry<i32>) -> Vec<LineString<i32>> {
         match geometry {
             Geometry::LineString(line_string) => {
-                // .lines() returns an iterator over individual Line segments
                 vec![line_string]
             }
-            Geometry::MultiLineString(multi_line_string) => {
-                // MultiLineString contains multiple LineStrings;
-                // iterate over them, get lines for each, and flatten
-                multi_line_string
-                    .into_iter()
-                    .collect()
-            }
-            _ => {
-                // Handle or ignore other geometry variants (like Point, Polygon, etc.)
-                Vec::new()
-            }
+            Geometry::MultiLineString(multi_line_string) => multi_line_string.into_iter().collect(),
+            _ => Vec::new(),
         }
     }
 
-    pub fn read_mvt_tile2(
+    pub fn read_mvt_tile(
         &self,
         bytes: &[u8],
         tile_key: &TileKey,
     ) -> MvtResult<Vec<(MapGeomObject, MapGeometry<f32>)>> {
         let reader = MvtReaderRef::new(bytes)?;
-        let kk = 512.0f32 / 4096.0;
+        let koef = 512.0f32 / 4096.0;
         let mut result = self.mvt_s.parse(reader.layers(), |feature| {
             let mut res = vec![];
             let geom_type = feature.geom_type();
             let geometry = feature.geometry();
 
-            if let Some(geom_type) = geom_type && geometry.is_ok() {
+            if let Some(geom_type) = geom_type
+                && geometry.is_ok()
+            {
                 let geometry = geometry.unwrap();
                 if geom_type == GeomType::LINESTRING {
                     for line in Self::get_all_lines(geometry) {
                         let ls: LineString<f32> = line
                             .coords_iter()
                             .map(|coord| {
-                                coord! { x: coord.x as f32 * kk, y: coord.y as f32 * kk}
+                                coord! { x: coord.x as f32 * koef, y: coord.y as f32 * koef}
                             })
                             .collect();
 
@@ -71,14 +60,14 @@ impl MvtParser {
                     match geometry {
                         MvtGeometry::Polygon(poly) => {
                             let ls: Polygon<f32> = poly.map_coords(|coord| {
-                                coord! { x: coord.x as f32 * kk, y: coord.y as f32 * kk}
+                                coord! { x: coord.x as f32 * koef, y: coord.y as f32 * koef}
                             });
                             res.push(MapGeometry::Poly(ls));
                         }
                         MvtGeometry::MultiPolygon(polis) => {
                             for poly in polis {
                                 let ls: Polygon<f32> = poly.map_coords(|coord| {
-                                    coord! { x: coord.x as f32 * kk, y: coord.y as f32 * kk}
+                                    coord! { x: coord.x as f32 * koef, y: coord.y as f32 * koef}
                                 });
                                 res.push(MapGeometry::Poly(ls));
                             }
@@ -102,222 +91,6 @@ impl MvtParser {
         Ok(fixed)
     }
 
-    pub fn read_mvt_tile(
-        bytes: &[u8],
-        tile_key: &TileKey,
-    ) -> MvtResult<Vec<(MapGeomObject, MapGeometry<f32>)>> {
-        let mut res = vec![];
-        let reader = MvtReaderRef::new(bytes)?;
-
-        for layer in reader.layers() {
-            // println!("layer: {:?}",layer.name());
-            if layer.name() == "road" {
-                for feature in layer.features() {
-                    if let Some(geom_type) = feature.geom_type()
-                        && geom_type == GeomType::LINESTRING
-                    {
-                        let mut layer: i64 = 0;
-                        let mut highway_kind_name: Option<&str> = None;
-                        let mut brunnel = false;
-                        let mut ramp = false;
-                        for property in feature.properties() {
-                            let (key, value) = property?;
-                            if key == "layer" {
-                                layer = LocalMvtValue(value).into();
-                            } else if key == "class" {
-                                let road_class: String = LocalMvtValue(value).into();
-                                highway_kind_name = match road_class.as_str() {
-                                    "motorway" => Some("motorway"),
-                                    "primary" => Some("primary"),
-                                    "secondary" => Some("secondary"),
-                                    "tertiary" => Some("tertiary"),
-                                    "unclassified" => Some("unclassified"),
-                                    "residential" => Some("residential"),
-                                    "minor" => Some("residential"),
-                                    "service" => Some("service"),
-                                    "trunk" => Some("trunk"),
-                                    _ => None,
-                                };
-                            } else if key == "brunnel" {
-                                brunnel = true;
-                            } else if key == "ramp" {
-                                ramp = true;
-                            }
-                        }
-
-                        if let Some(highway_kind_name) = highway_kind_name {
-                            let mut bb = highway_kind_name.to_string();
-                            if ramp {
-                                bb = format!("{highway_kind_name}_link");
-                            }
-                            let highway_kind = HighwayKind::from_descr(bb.as_str()).unwrap();
-                            let kk = 512.0f32 / 4096.0;
-                            let geom_object = MapGeomObject {
-                                id: -1,
-                                kind: MapGeomObjectKind::Way(WayInfo {
-                                    line_kind: LineKind::Highway { kind: highway_kind },
-                                    layer: if brunnel { layer as i32 } else { 0 },
-                                    layer_kind: LayerKind::None,
-                                    name_en: None,
-                                }),
-                            };
-                            for line in Self::get_all_lines(feature.geometry()?) {
-                                let ls: LineString<f32> = line
-                                    .coords_iter()
-                                    .map(|coord| {
-                                        coord! { x: coord.x as f32 * kk, y: coord.y as f32 * kk}
-                                    })
-                                    .collect();
-
-                                res.push((geom_object.clone(), MapGeometry::Line(ls)));
-                            }
-                        }
-                    }
-                }
-            } else if layer.name() == "water" {
-                let kk = 512.0f32 / 4096.0;
-                let geom_object = MapGeomObject {
-                    id: -1,
-                    kind: MapGeomObjectKind::Nature(NatureKind::Water),
-                };
-                for feature in layer.features() {
-                    if let Some(geom_type) = feature.geom_type()
-                        && geom_type == GeomType::POLYGON
-                    {
-                        match feature.geometry()? {
-                            MvtGeometry::Polygon(poly) => {
-                                let ls: Polygon<f32> = poly.map_coords(|coord| {
-                                    coord! { x: coord.x as f32 * kk, y: coord.y as f32 * kk}
-                                });
-                                res.push((geom_object.clone(), MapGeometry::Poly(ls)));
-                            }
-                            MvtGeometry::MultiPolygon(polis) => {
-                                for poly in polis {
-                                    let ls: Polygon<f32> = poly.map_coords(|coord| {
-                                        coord! { x: coord.x as f32 * kk, y: coord.y as f32 * kk}
-                                    });
-
-                                    res.push((geom_object.clone(), MapGeometry::Poly(ls)));
-                                }
-                            }
-                            _ => {}
-                        }
-                    }
-                }
-            } else if layer.name() == "landuse"
-                || layer.name() == "landcover"
-                || layer.name() == "park"
-                || layer.name() == "grass"
-                || layer.name() == "wood"
-                // || layer.name() == "scrub"
-                // || layer.name() == "forest"
-                // || layer.name() == "vegetation"
-            {
-                // println!("layer: {:?}",layer.name());
-                for feature in layer.features() {
-                    // for property in feature.properties() {
-                    //     let (key, value) = property?;
-                    //     // println!("key: {:?}, value: {:?}", key, value);
-                    //     if key == "class" || key != "class"  {
-                    //         let class_type: String = LocalMvtValue(value).into();
-                    //         // println!("ClassType: {}", class_type);
-                    //         if layer.name() == "park"
-                    //         || layer.name() == "grass"
-                    //         || layer.name() == "wood"
-                    //             || class_type == "wood"
-                    //             || class_type == "park"
-                    //             || class_type == "grass"
-                    //             || class_type == "garden"
-                    //             || class_type == "heath"
-                    //             || class_type == "grassland"
-                    //             || class_type == "nature_reserve"
-                    //             || class_type == "geopark"
-                    //             || class_type == "farmland"
-                    //             || class_type == "national_park"
-                    //         {
-                    //
-                    //         }
-                    //     }
-                    //     // println!("key: {:?}, value: {:?}",key, value);
-                    // }
-
-                    let kk = 512.0f32 / 4096.0;
-                    let geom_object = MapGeomObject {
-                        id: -1,
-                        kind: MapGeomObjectKind::Nature(NatureKind::Forest),
-                    };
-                    if let Some(geom_type) = feature.geom_type()
-                        && geom_type == GeomType::POLYGON
-                    {
-                        match feature.geometry()? {
-                            MvtGeometry::Polygon(poly) => {
-                                let ls: Polygon<f32> = poly.map_coords(|coord| {
-                                    coord! { x: coord.x as f32 * kk, y: coord.y as f32 * kk}
-                                });
-                                res.push((geom_object.clone(), MapGeometry::Poly(ls)));
-                            }
-                            MvtGeometry::MultiPolygon(polis) => {
-                                for poly in polis {
-                                    let ls: Polygon<f32> = poly.map_coords(|coord| {
-                                        coord! { x: coord.x as f32 * kk, y: coord.y as f32 * kk}
-                                    });
-
-                                    res.push((
-                                        geom_object.clone(),
-                                        MapGeometry::Poly(ls),
-                                    ));
-                                }
-                            }
-                            _ => {}
-                        }
-                    }
-                }
-            } else if layer.name() == "building" && tile_key.zoom_level >= MAX_ZOOM_LEVEL - 1 {
-                let kk = 512.0f32 / 4096.0;
-                let geom_object = MapGeomObject {
-                    id: -1,
-                    kind: MapGeomObjectKind::Building(3),
-                };
-                for feature in layer.features() {
-                    if let Some(geom_type) = feature.geom_type()
-                        && geom_type == GeomType::POLYGON
-                    {
-                        match feature.geometry()? {
-                            MvtGeometry::Polygon(poly) => {
-                                let ls: Polygon<f32> = poly.map_coords(|coord| {
-                                    coord! { x: coord.x as f32 * kk, y: coord.y as f32 * kk}
-                                });
-                                res.push((geom_object.clone(), MapGeometry::Poly(ls)));
-                            }
-                            MvtGeometry::MultiPolygon(polis) => {
-                                for poly in polis {
-                                    let ls: Polygon<f32> = poly.map_coords(|coord| {
-                                        coord! { x: coord.x as f32 * kk, y: coord.y as f32 * kk}
-                                    });
-
-                                    res.push((geom_object.clone(), MapGeometry::Poly(ls)));
-                                }
-                            }
-                            _ => {}
-                        }
-                    }
-                }
-            }
-        }
-
-        res.sort_by(|(a, _), (b, _)| a.cmp(b));
-
-        let fixed = res
-            .into_iter()
-            .map(|(geom, obj)| {
-                let obj_fixed = Self::convert_and_restore_data(&obj, tile_key);
-                (geom, obj_fixed)
-            })
-            .collect();
-
-        Ok(fixed)
-    }
-
     fn convert_and_restore_data(
         geometry: &MapGeometry<f32>,
         tile_key: &TileKey,
@@ -325,29 +98,23 @@ impl MvtParser {
         // FIXME Zoom level handling
         let factor = 2.0f32.powf((MAX_ZOOM_LEVEL - tile_key.zoom_level) as f32);
         match geometry {
-            MapGeometry::Line(line) => MapGeometry::Line(line.map_coords(|coord| {
-                coord * factor
-            })),
-            MapGeometry::Poly(poly) => MapGeometry::Poly(poly.map_coords(|coord| {
-                coord * factor
-            })),
-            MapGeometry::Coord(coord) => MapGeometry::Coord(
-                *coord * factor,
-            ),
+            MapGeometry::Line(line) => MapGeometry::Line(line.map_coords(|coord| coord * factor)),
+            MapGeometry::Poly(poly) => MapGeometry::Poly(poly.map_coords(|coord| coord * factor)),
+            MapGeometry::Coord(coord) => MapGeometry::Coord(*coord * factor),
         }
     }
 }
 
-pub(crate) struct LocalMvtValue2(pub MvtValue);
+pub(crate) struct LocalMvtValue(pub MvtValue);
 
-impl LocalMvtValue2 {
+impl LocalMvtValue {
     fn unexpected_type<T>(&self, expected: &str) -> Option<T> {
         error!("Unexpected {} MvtValueRef: {:?}", expected, self.0);
         None
     }
 }
-impl From<LocalMvtValue2> for Option<i64> {
-    fn from(value: LocalMvtValue2) -> Self {
+impl From<LocalMvtValue> for Option<i64> {
+    fn from(value: LocalMvtValue) -> Self {
         match value.0 {
             MvtValue::SInt(value) => Some(value),
             _ => value.unexpected_type("i64"),
@@ -355,8 +122,8 @@ impl From<LocalMvtValue2> for Option<i64> {
     }
 }
 
-impl From<LocalMvtValue2> for Option<String> {
-    fn from(value: LocalMvtValue2) -> Self {
+impl From<LocalMvtValue> for Option<String> {
+    fn from(value: LocalMvtValue) -> Self {
         match value.0 {
             MvtValue::String(value) => Some(value),
             _ => value.unexpected_type("String"),
@@ -364,38 +131,11 @@ impl From<LocalMvtValue2> for Option<String> {
     }
 }
 
-impl From<LocalMvtValue2> for Option<bool> {
-    fn from(value: LocalMvtValue2) -> Self {
+impl From<LocalMvtValue> for Option<bool> {
+    fn from(value: LocalMvtValue) -> Self {
         match value.0 {
             MvtValue::Bool(value) => Some(value),
             _ => value.unexpected_type("bool"),
-        }
-    }
-}
-
-pub(crate) struct LocalMvtValue<'a>(pub MvtValueRef<'a>);
-impl From<LocalMvtValue<'_>> for i64 {
-    fn from(value: LocalMvtValue<'_>) -> Self {
-        match value.0 {
-            MvtValueRef::SInt(value) => value,
-            _ => panic!("Unexpected MvtValueRef"),
-        }
-    }
-}
-impl <'a> From<&'a LocalMvtValue<'a>> for i64 {
-    fn from(value: &LocalMvtValue<'a>) -> Self {
-        match value.0 {
-            MvtValueRef::SInt(value) => value,
-            _ => panic!("Unexpected MvtValueRef"),
-        }
-    }
-}
-
-impl From<LocalMvtValue<'_>> for String {
-    fn from(value: LocalMvtValue<'_>) -> Self {
-        match value.0 {
-            MvtValueRef::String(value) => value.to_string(),
-            _ => panic!("Unexpected MvtValueRef"),
         }
     }
 }

--- a/map/src/tiles/mvt/mvt_parser.rs
+++ b/map/src/tiles/mvt/mvt_parser.rs
@@ -42,7 +42,7 @@ impl MvtParser {
     }
 
     pub fn read_mvt_tile2(
-        &mut self,
+        &self,
         bytes: &[u8],
         tile_key: &TileKey,
     ) -> MvtResult<Vec<(MapGeomObject, MapGeometry<f32>)>> {

--- a/map/src/tiles/mvt/mvt_parser.rs
+++ b/map/src/tiles/mvt/mvt_parser.rs
@@ -11,6 +11,12 @@ pub struct MvtParser {
     schema_parser: MvtSchemeParser,
 }
 
+impl Default for MvtParser {
+    fn default() -> Self {
+        MvtParser::new()
+    }
+}
+
 impl MvtParser {
     pub fn new() -> Self {
         Self {
@@ -48,10 +54,7 @@ impl MvtParser {
             let geom_type = feature.geom_type();
             let geometry = feature.geometry();
 
-            if let Some(geom_type) = geom_type
-                && geometry.is_ok()
-            {
-                let geometry = geometry.unwrap();
+            if let (Some(geom_type), Some(geometry)) = (geom_type, geometry.ok()) {
                 // TODO Add points later
                 if geom_type == GeomType::LINESTRING {
                     for line in Self::get_all_lines(geometry) {

--- a/map/src/tiles/mvt/mvt_parser.rs
+++ b/map/src/tiles/mvt/mvt_parser.rs
@@ -4,6 +4,7 @@ use fast_mvt::proto::GeomType;
 use fast_mvt::{MvtGeometry, MvtReaderRef, MvtResult, MvtValue, MvtValueRef};
 use geo::{CoordsIter, MapCoords};
 use geo_types::{coord, Geometry, LineString, Polygon};
+use log::error;
 use osm::map::{
     HighwayKind, LayerKind, LineKind, MapGeomObject, MapGeomObjectKind, MapGeometry, NatureKind,
     WayInfo,
@@ -320,29 +321,35 @@ impl MvtParser {
 
 pub(crate) struct LocalMvtValue2(pub MvtValue);
 
-impl From<LocalMvtValue2> for i64 {
+impl LocalMvtValue2 {
+    fn unexpected_type<T>(&self, expected: &str) -> Option<T> {
+        error!("Unexpected {} MvtValueRef: {:?}", expected, self.0);
+        None
+    }
+}
+impl From<LocalMvtValue2> for Option<i64> {
     fn from(value: LocalMvtValue2) -> Self {
         match value.0 {
-            MvtValue::SInt(value) => value,
-            _ => panic!("Unexpected i64 MvtValueRef: {:?}", value.0),
+            MvtValue::SInt(value) => Some(value),
+            _ => value.unexpected_type("i64"),
         }
     }
 }
 
-impl From<LocalMvtValue2> for String {
+impl From<LocalMvtValue2> for Option<String> {
     fn from(value: LocalMvtValue2) -> Self {
         match value.0 {
-            MvtValue::String(value) => value,
-            _ => panic!("Unexpected String MvtValueRef: {:?}", value.0),
+            MvtValue::String(value) => Some(value),
+            _ => value.unexpected_type("String"),
         }
     }
 }
 
-impl From<LocalMvtValue2> for bool {
+impl From<LocalMvtValue2> for Option<bool> {
     fn from(value: LocalMvtValue2) -> Self {
         match value.0 {
-            MvtValue::Bool(value) => value,
-            _ => panic!("Unexpected bool MvtValueRef: {:?}", value.0),
+            MvtValue::Bool(value) => Some(value),
+            _ => value.unexpected_type("bool"),
         }
     }
 }

--- a/map/src/tiles/mvt/mvt_parser.rs
+++ b/map/src/tiles/mvt/mvt_parser.rs
@@ -55,8 +55,9 @@ impl MvtParser {
             let geometry = feature.geometry();
 
             if let Some(geom_type) = geom_type && geometry.is_ok() {
+                let geometry = geometry.unwrap();
                 if geom_type == GeomType::LINESTRING {
-                    for line in Self::get_all_lines(feature.geometry().unwrap()) {
+                    for line in Self::get_all_lines(geometry) {
                         let ls: LineString<f32> = line
                             .coords_iter()
                             .map(|coord| {
@@ -66,7 +67,25 @@ impl MvtParser {
 
                         res.push(MapGeometry::Line(ls));
                     }
-                } else if geom_type == GeomType::POLYGON {}
+                } else if geom_type == GeomType::POLYGON {
+                    match geometry {
+                        MvtGeometry::Polygon(poly) => {
+                            let ls: Polygon<f32> = poly.map_coords(|coord| {
+                                coord! { x: coord.x as f32 * kk, y: coord.y as f32 * kk}
+                            });
+                            res.push(MapGeometry::Poly(ls));
+                        }
+                        MvtGeometry::MultiPolygon(polis) => {
+                            for poly in polis {
+                                let ls: Polygon<f32> = poly.map_coords(|coord| {
+                                    coord! { x: coord.x as f32 * kk, y: coord.y as f32 * kk}
+                                });
+                                res.push(MapGeometry::Poly(ls));
+                            }
+                        }
+                        _ => {}
+                    }
+                }
             }
             res
         });

--- a/map/src/tiles/mvt/mvt_parser.rs
+++ b/map/src/tiles/mvt/mvt_parser.rs
@@ -324,7 +324,7 @@ impl From<LocalMvtValue2> for i64 {
     fn from(value: LocalMvtValue2) -> Self {
         match value.0 {
             MvtValue::SInt(value) => value,
-            _ => panic!("Unexpected MvtValueRef"),
+            _ => panic!("Unexpected i64 MvtValueRef: {:?}", value.0),
         }
     }
 }
@@ -333,7 +333,7 @@ impl From<LocalMvtValue2> for String {
     fn from(value: LocalMvtValue2) -> Self {
         match value.0 {
             MvtValue::String(value) => value,
-            _ => panic!("Unexpected MvtValueRef"),
+            _ => panic!("Unexpected String MvtValueRef: {:?}", value.0),
         }
     }
 }
@@ -342,7 +342,7 @@ impl From<LocalMvtValue2> for bool {
     fn from(value: LocalMvtValue2) -> Self {
         match value.0 {
             MvtValue::Bool(value) => value,
-            _ => panic!("Unexpected MvtValueRef"),
+            _ => panic!("Unexpected bool MvtValueRef: {:?}", value.0),
         }
     }
 }

--- a/map/src/tiles/mvt/mvt_scheme_parser.rs
+++ b/map/src/tiles/mvt/mvt_scheme_parser.rs
@@ -4,6 +4,7 @@ use osm::map::{
     HighwayKind, LayerKind, LineKind, MapGeomObject, MapGeomObjectKind, MapGeometry, WayInfo,
 };
 use std::collections::HashMap;
+use std::sync::Arc;
 
 pub(crate) struct MvtSchemeParser {
     config: HashMap<&'static str, MvtPropHandler>,
@@ -18,7 +19,7 @@ impl MvtSchemeParser {
             let brunnel: bool = !brunnel.is_empty();
             let ramp: bool = handler.get_prop_value("ramp");
 
-            let mut highway_kind_name: Option<&str> = match road_class.as_str() {
+            let highway_kind_name: Option<&str> = match road_class.as_str() {
                 "motorway" => Some("motorway"),
                 "primary" => Some("primary"),
                 "secondary" => Some("secondary"),
@@ -61,7 +62,7 @@ impl MvtSchemeParser {
     }
 
     pub fn parse<'b, F>(
-        &mut self,
+        &self,
         layers: impl Iterator<Item = MvtLayerRef<'b>>,
         geom_builder: F,
     ) -> Vec<(MapGeomObject, MapGeometry<f32>)>
@@ -70,8 +71,8 @@ impl MvtSchemeParser {
     {
         let mut res = vec![];
         for layer in layers {
-            let handler = self.config.get_mut(layer.name());
-            if let Some(handler) = handler {
+            let mut handler = self.config.get(layer.name()).cloned();
+            if let Some(handler) = handler.as_mut() {
                 for feature in layer.features() {
                     let data = handler.build(&feature, &geom_builder);
                     res.extend(data);
@@ -83,20 +84,21 @@ impl MvtSchemeParser {
     }
 }
 
+#[derive(Clone)]
 struct MvtPropHandler {
     layer: &'static str,
-    builder: Box<dyn Fn(&Self) -> Option<MapGeomObject>>,
+    builder: Arc<dyn Fn(&Self) -> Option<MapGeomObject> + Send + Sync>,
     map: HashMap<String, MvtValue>,
 }
 
 impl MvtPropHandler {
     pub fn new<F>(layer: &'static str, builder: F) -> Self
     where
-        F: Fn(&Self) -> Option<MapGeomObject> + 'static,
+        F: Fn(&Self) -> Option<MapGeomObject> + Send + Sync + 'static,
     {
         Self {
             layer,
-            builder: Box::new(builder),
+            builder: Arc::new(builder),
             map: HashMap::new(),
         }
     }

--- a/map/src/tiles/mvt/mvt_scheme_parser.rs
+++ b/map/src/tiles/mvt/mvt_scheme_parser.rs
@@ -1,6 +1,9 @@
 use crate::tiles::mvt::mvt_parser::LocalMvtValue2;
 use fast_mvt::{MvtFeatureRef, MvtLayerRef, MvtValue};
-use osm::map::{HighwayKind, LayerKind, LineKind, MapGeomObject, MapGeomObjectKind, MapGeometry, NatureKind, WayInfo};
+use osm::map::{
+    HighwayKind, LayerKind, LineKind, MapGeomObject, MapGeomObjectKind, MapGeometry, NatureKind,
+    WayInfo,
+};
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -35,16 +38,14 @@ impl MvtSchemeParser {
                 if ramp {
                     bb = format!("{highway_kind_name}_link");
                 }
-                HighwayKind::from_descr(bb.as_str()).map(|kind| {
-                    MapGeomObject {
-                        id: -1,
-                        kind: MapGeomObjectKind::Way(WayInfo {
-                            line_kind: LineKind::Highway { kind },
-                            layer: if brunnel { road_layer as i32 } else { 0 },
-                            layer_kind: LayerKind::None,
-                            name_en: None,
-                        }),
-                    }
+                HighwayKind::from_descr(bb.as_str()).map(|kind| MapGeomObject {
+                    id: -1,
+                    kind: MapGeomObjectKind::Way(WayInfo {
+                        line_kind: LineKind::Highway { kind },
+                        layer: if brunnel { road_layer as i32 } else { 0 },
+                        layer_kind: LayerKind::None,
+                        name_en: None,
+                    }),
                 })
             })
         });
@@ -56,15 +57,43 @@ impl MvtSchemeParser {
             })
         });
 
+        let forest_handler = MvtPropHandler::new("forest", |_| {
+            Some(MapGeomObject {
+                id: -1,
+                kind: MapGeomObjectKind::Nature(NatureKind::Forest),
+            })
+        });
+
+        let wood_handler = MvtPropHandler::new("wood", |_| {
+            Some(MapGeomObject {
+                id: -1,
+                kind: MapGeomObjectKind::Nature(NatureKind::Forest),
+            })
+        });
+
+        let grass_handler = MvtPropHandler::new("grass", |_| {
+            Some(MapGeomObject {
+                id: -1,
+                kind: MapGeomObjectKind::Nature(NatureKind::Park),
+            })
+        });
+
         let building_handler = MvtPropHandler::new("building", |handler| {
             let height: i64 = handler.get_prop_value("height");
             Some(MapGeomObject {
                 id: -1,
-                kind: MapGeomObjectKind::Building((height / 6) as u16)
+                kind: MapGeomObjectKind::Building((height / 6) as u16),
             })
         });
 
-        Self::new_from_handlers(vec![road_handler, water_handler, building_handler])
+        Self::new_from_handlers(vec![
+            road_handler,
+            water_handler,
+            building_handler,
+            forest_handler,
+            wood_handler,
+            grass_handler,
+        ])
     }
 
     fn new_from_handlers(handlers: Vec<MvtPropHandler>) -> Self {

--- a/map/src/tiles/mvt/mvt_scheme_parser.rs
+++ b/map/src/tiles/mvt/mvt_scheme_parser.rs
@@ -30,21 +30,22 @@ impl MvtSchemeParser {
                 _ => None,
             };
 
-            highway_kind_name.map(|highway_kind_name| {
+            highway_kind_name.and_then(|highway_kind_name| {
                 let mut bb = highway_kind_name.to_string();
                 if ramp {
                     bb = format!("{highway_kind_name}_link");
                 }
-                let highway_kind = HighwayKind::from_descr(bb.as_str()).unwrap();
-                MapGeomObject {
-                    id: -1,
-                    kind: MapGeomObjectKind::Way(WayInfo {
-                        line_kind: LineKind::Highway { kind: highway_kind },
-                        layer: if brunnel { road_layer as i32 } else { 0 },
-                        layer_kind: LayerKind::None,
-                        name_en: None,
-                    }),
-                }
+                HighwayKind::from_descr(bb.as_str()).map(|kind| {
+                    MapGeomObject {
+                        id: -1,
+                        kind: MapGeomObjectKind::Way(WayInfo {
+                            line_kind: LineKind::Highway { kind },
+                            layer: if brunnel { road_layer as i32 } else { 0 },
+                            layer_kind: LayerKind::None,
+                            name_en: None,
+                        }),
+                    }
+                })
             })
         });
 
@@ -55,7 +56,15 @@ impl MvtSchemeParser {
             })
         });
 
-        Self::new_from_handlers(vec![road_handler, water_handler])
+        let building_handler = MvtPropHandler::new("building", |handler| {
+            let height: i64 = handler.get_prop_value("height");
+            Some(MapGeomObject {
+                id: -1,
+                kind: MapGeomObjectKind::Building((height / 6) as u16)
+            })
+        });
+
+        Self::new_from_handlers(vec![road_handler, water_handler, building_handler])
     }
 
     fn new_from_handlers(handlers: Vec<MvtPropHandler>) -> Self {

--- a/map/src/tiles/mvt/mvt_scheme_parser.rs
+++ b/map/src/tiles/mvt/mvt_scheme_parser.rs
@@ -1,8 +1,6 @@
 use crate::tiles::mvt::mvt_parser::LocalMvtValue2;
 use fast_mvt::{MvtFeatureRef, MvtLayerRef, MvtValue};
-use osm::map::{
-    HighwayKind, LayerKind, LineKind, MapGeomObject, MapGeomObjectKind, MapGeometry, WayInfo,
-};
+use osm::map::{HighwayKind, LayerKind, LineKind, MapGeomObject, MapGeomObjectKind, MapGeometry, NatureKind, WayInfo};
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -12,7 +10,7 @@ pub(crate) struct MvtSchemeParser {
 
 impl MvtSchemeParser {
     pub fn new_map_tiler_v4() -> Self {
-        let handlers = vec![MvtPropHandler::new("road", |handler| {
+        let road_handler = MvtPropHandler::new("road", |handler| {
             let road_layer: i64 = handler.get_prop_value("layer");
             let road_class: String = handler.get_prop_value("class");
             let brunnel: String = handler.get_prop_value("brunnel");
@@ -48,8 +46,16 @@ impl MvtSchemeParser {
                     }),
                 }
             })
-        })];
-        Self::new_from_handlers(handlers)
+        });
+
+        let water_handler = MvtPropHandler::new("water", |_| {
+            Some(MapGeomObject {
+                id: -1,
+                kind: MapGeomObjectKind::Nature(NatureKind::Water),
+            })
+        });
+
+        Self::new_from_handlers(vec![road_handler, water_handler])
     }
 
     fn new_from_handlers(handlers: Vec<MvtPropHandler>) -> Self {

--- a/map/src/tiles/mvt/mvt_scheme_parser.rs
+++ b/map/src/tiles/mvt/mvt_scheme_parser.rs
@@ -134,12 +134,11 @@ impl MvtPropHandler {
 
     pub fn get_prop_value<T: Default>(&self, key: &'static str) -> T
     where
-        T: From<LocalMvtValue2>,
+        Option<T>: From<LocalMvtValue2>,
     {
         self.map
             .get(key)
-            // FIXME how to remove clone?
-            .map(|value| LocalMvtValue2(value.clone()).into())
+            .and_then(|value| LocalMvtValue2(value.clone()).into())
             .unwrap_or_default()
     }
 }

--- a/map/src/tiles/mvt/mvt_scheme_parser.rs
+++ b/map/src/tiles/mvt/mvt_scheme_parser.rs
@@ -183,46 +183,46 @@ impl MvtPropHandler {
 
     pub fn get_prop_value<T: Default>(&self, key: &'static str) -> T
     where
-        Option<T>: From<LocalMvtValue>,
+        for<'a> Option<T>: From<LocalMvtValue<'a>>,
     {
         self.map
             .get(key)
             // How to get rid of clone()?
-            .and_then(|value| LocalMvtValue(value.clone()).into())
+            .and_then(|value| LocalMvtValue(value).into())
             .unwrap_or_default()
     }
 }
 
-struct LocalMvtValue(pub MvtValue);
+struct LocalMvtValue<'a>(pub &'a MvtValue);
 
-impl LocalMvtValue {
+impl LocalMvtValue<'_> {
     fn unexpected_type<T>(&self, expected: &str) -> Option<T> {
-        error!("Unexpected {} MvtValueRef: {:?}", expected, self.0);
+        error!("Unexpected {} MvtValue: {:?}", expected, self.0);
         None
     }
 }
-impl From<LocalMvtValue> for Option<i64> {
+impl From<LocalMvtValue<'_>> for Option<i64> {
     fn from(value: LocalMvtValue) -> Self {
         match value.0 {
-            MvtValue::SInt(value) => Some(value),
+            MvtValue::SInt(value) => Some(*value),
             _ => value.unexpected_type("i64"),
         }
     }
 }
 
-impl From<LocalMvtValue> for Option<String> {
+impl From<LocalMvtValue<'_>> for Option<String> {
     fn from(value: LocalMvtValue) -> Self {
         match value.0 {
-            MvtValue::String(value) => Some(value),
+            MvtValue::String(value) => Some(value.clone()),
             _ => value.unexpected_type("String"),
         }
     }
 }
 
-impl From<LocalMvtValue> for Option<bool> {
+impl From<LocalMvtValue<'_>> for Option<bool> {
     fn from(value: LocalMvtValue) -> Self {
         match value.0 {
-            MvtValue::Bool(value) => Some(value),
+            MvtValue::Bool(value) => Some(*value),
             _ => value.unexpected_type("bool"),
         }
     }

--- a/map/src/tiles/mvt/mvt_scheme_parser.rs
+++ b/map/src/tiles/mvt/mvt_scheme_parser.rs
@@ -84,7 +84,7 @@ impl MvtSchemeParser {
             Some(MapGeomObject {
                 id: -1,
                 // fyi, 3 - koef to convert map tiler height to osm levels, 2 - feature processor multiplier
-                kind: MapGeomObjectKind::Building((height / (3 * 2)) as u16),
+                kind: MapGeomObjectKind::Building(((height / (3 * 2)) as u16).clamp(0, 100)),
             })
         });
 

--- a/map/src/tiles/mvt/mvt_scheme_parser.rs
+++ b/map/src/tiles/mvt/mvt_scheme_parser.rs
@@ -71,8 +71,7 @@ impl MvtSchemeParser {
     {
         let mut res = vec![];
         for layer in layers {
-            let mut handler = self.config.get(layer.name()).cloned();
-            if let Some(handler) = handler.as_mut() {
+            if let Some(mut handler) = self.config.get(layer.name()).cloned() {
                 for feature in layer.features() {
                     let data = handler.build(&feature, &geom_builder);
                     res.extend(data);

--- a/map/src/tiles/mvt/mvt_scheme_parser.rs
+++ b/map/src/tiles/mvt/mvt_scheme_parser.rs
@@ -6,7 +6,7 @@ use osm::map::{
 use std::collections::HashMap;
 
 pub(crate) struct MvtSchemeParser {
-    config: HashMap<&'static str, MvtPropHandler<'static>>,
+    config: HashMap<&'static str, MvtPropHandler>,
 }
 
 impl MvtSchemeParser {
@@ -51,7 +51,7 @@ impl MvtSchemeParser {
         Self::new_from_handlers(handlers)
     }
 
-    fn new_from_handlers(handlers: Vec<MvtPropHandler<'static>>) -> Self {
+    fn new_from_handlers(handlers: Vec<MvtPropHandler>) -> Self {
         Self {
             config: handlers
                 .into_iter()
@@ -83,13 +83,13 @@ impl MvtSchemeParser {
     }
 }
 
-struct MvtPropHandler<'a> {
+struct MvtPropHandler {
     layer: &'static str,
     builder: Box<dyn Fn(&Self) -> Option<MapGeomObject>>,
     map: HashMap<String, MvtValue>,
 }
 
-impl<'a> MvtPropHandler<'a> {
+impl MvtPropHandler {
     pub fn new<F>(layer: &'static str, builder: F) -> Self
     where
         F: Fn(&Self) -> Option<MapGeomObject> + 'static,

--- a/map/src/tiles/mvt/mvt_scheme_parser.rs
+++ b/map/src/tiles/mvt/mvt_scheme_parser.rs
@@ -1,5 +1,5 @@
-use crate::tiles::mvt::mvt_parser::LocalMvtValue;
 use fast_mvt::{MvtFeatureRef, MvtLayerRef, MvtValue};
+use log::error;
 use osm::map::{
     HighwayKind, LayerKind, LineKind, MapGeomObject, MapGeomObjectKind, MapGeometry, NatureKind,
     WayInfo,
@@ -83,7 +83,8 @@ impl MvtSchemeParser {
             let height: i64 = handler.get_prop_value("height");
             Some(MapGeomObject {
                 id: -1,
-                kind: MapGeomObjectKind::Building((height / 6) as u16),
+                // fyi, 3 - koef to convert map tiler height to osm levels, 2 - feature processor multiplier
+                kind: MapGeomObjectKind::Building((height / (3 * 2)) as u16),
             })
         });
 
@@ -110,9 +111,9 @@ impl MvtSchemeParser {
         &self,
         layers: impl Iterator<Item = MvtLayerRef<'b>>,
         geom_builder: F,
-    ) -> Vec<(MapGeomObject, MapGeometry<f32>)>
+    ) -> Vec<(MapGeomObject, MapGeometry<i32>)>
     where
-        F: Fn(&MvtFeatureRef) -> Vec<MapGeometry<f32>>,
+        F: Fn(&MvtFeatureRef) -> Vec<MapGeometry<i32>>,
     {
         let mut res = vec![];
         for layer in layers {
@@ -155,9 +156,9 @@ impl MvtPropHandler {
         &mut self,
         feature: &MvtFeatureRef<'_>,
         geom_builder: &F,
-    ) -> Vec<(MapGeomObject, MapGeometry<f32>)>
+    ) -> Vec<(MapGeomObject, MapGeometry<i32>)>
     where
-        F: Fn(&MvtFeatureRef) -> Vec<MapGeometry<f32>>,
+        F: Fn(&MvtFeatureRef) -> Vec<MapGeometry<i32>>,
     {
         self.map.clear();
         for property in feature.properties() {
@@ -185,5 +186,40 @@ impl MvtPropHandler {
             .get(key)
             .and_then(|value| LocalMvtValue(value.clone()).into())
             .unwrap_or_default()
+    }
+}
+
+struct LocalMvtValue(pub MvtValue);
+
+impl LocalMvtValue {
+    fn unexpected_type<T>(&self, expected: &str) -> Option<T> {
+        error!("Unexpected {} MvtValueRef: {:?}", expected, self.0);
+        None
+    }
+}
+impl From<LocalMvtValue> for Option<i64> {
+    fn from(value: LocalMvtValue) -> Self {
+        match value.0 {
+            MvtValue::SInt(value) => Some(value),
+            _ => value.unexpected_type("i64"),
+        }
+    }
+}
+
+impl From<LocalMvtValue> for Option<String> {
+    fn from(value: LocalMvtValue) -> Self {
+        match value.0 {
+            MvtValue::String(value) => Some(value),
+            _ => value.unexpected_type("String"),
+        }
+    }
+}
+
+impl From<LocalMvtValue> for Option<bool> {
+    fn from(value: LocalMvtValue) -> Self {
+        match value.0 {
+            MvtValue::Bool(value) => Some(value),
+            _ => value.unexpected_type("bool"),
+        }
     }
 }

--- a/map/src/tiles/mvt/mvt_scheme_parser.rs
+++ b/map/src/tiles/mvt/mvt_scheme_parser.rs
@@ -1,0 +1,110 @@
+use crate::tiles::mvt::mvt_parser::LocalMvtValue2;
+use fast_mvt::{MvtFeatureRef, MvtLayerRef, MvtValue};
+use osm::map::{MapGeomObject, MapGeometry};
+use std::collections::HashMap;
+
+pub(crate) struct MvtSchemeParser {
+    config: HashMap<&'static str, MvtPropHandler<'static>>,
+}
+
+impl MvtSchemeParser {
+    pub fn new_map_tiler_v4() -> Self {
+        let handlers = vec![MvtPropHandler::new("road", |handler| {
+            let layer: Option<i64> = handler.get_prop_value("layer");
+            let road_class: Option<String> = handler.get_prop_value("class");
+            let brunnel: Option<bool> = handler.get_prop_value("brunnel");
+            let ramp: Option<bool> = handler.get_prop_value("ramp");
+
+            
+
+            todo!("MapGeomObject impl");
+            // true
+        })];
+        Self::new_from_handlers(handlers)
+    }
+
+    fn new_from_handlers(handlers: Vec<MvtPropHandler<'static>>) -> Self {
+        Self {
+            config: handlers
+                .into_iter()
+                .map(|item| (item.layer(), item))
+                .collect(),
+        }
+    }
+
+    pub fn parse<'b, F>(
+        &mut self,
+        layers: impl Iterator<Item = MvtLayerRef<'b>>,
+        geom_builder: F,
+    ) -> Vec<(MapGeomObject, MapGeometry<f32>)>
+    where
+        F: Fn(&MvtFeatureRef) -> Vec<MapGeometry<f32>>,
+    {
+        let mut res = vec![];
+        for layer in layers {
+            let handler = self.config.get_mut(layer.name());
+            if let Some(handler) = handler {
+                for feature in layer.features() {
+                    let data = handler.build(&feature, &geom_builder);
+                    res.extend(data);
+                }
+            }
+        }
+
+        res
+    }
+}
+
+struct MvtPropHandler<'a> {
+    layer: &'static str,
+    builder: Box<dyn Fn(&Self) -> MapGeomObject>,
+    map: HashMap<String, MvtValue>,
+}
+
+impl<'a> MvtPropHandler<'a> {
+    pub fn new<F>(layer: &'static str, builder: F) -> Self
+    where
+        F: Fn(&Self) -> MapGeomObject + 'static,
+    {
+        Self {
+            layer,
+            builder: Box::new(builder),
+            map: HashMap::new(),
+        }
+    }
+
+    pub fn layer(&self) -> &'static str {
+        self.layer
+    }
+
+    pub fn build<F>(
+        &mut self,
+        feature: &MvtFeatureRef<'_>,
+        geom_builder: &F,
+    ) -> Vec<(MapGeomObject, MapGeometry<f32>)>
+    where
+        F: Fn(&MvtFeatureRef) -> Vec<MapGeometry<f32>>,
+    {
+        self.map.clear();
+        for property in feature.properties() {
+            if let Ok((key, value)) = property {
+                self.map.insert(key.to_string(), value.into_owned());
+            }
+        }
+
+        let geom_obj = (self.builder)(&self);
+        let geom = geom_builder(feature);
+        geom.into_iter()
+            .map(|geometry| (geom_obj.clone(), geometry))
+            .collect()
+    }
+
+    pub fn get_prop_value<T>(&self, key: &'static str) -> Option<T>
+    where
+        T: From<LocalMvtValue2>,
+    {
+        self.map
+            .get(key)
+            .map(|value| LocalMvtValue2(value.clone()).into()) // TODO how to remove clone?
+    }
+}

--- a/map/src/tiles/mvt/mvt_scheme_parser.rs
+++ b/map/src/tiles/mvt/mvt_scheme_parser.rs
@@ -1,4 +1,4 @@
-use crate::tiles::mvt::mvt_parser::LocalMvtValue2;
+use crate::tiles::mvt::mvt_parser::LocalMvtValue;
 use fast_mvt::{MvtFeatureRef, MvtLayerRef, MvtValue};
 use osm::map::{
     HighwayKind, LayerKind, LineKind, MapGeomObject, MapGeomObjectKind, MapGeometry, NatureKind,
@@ -79,6 +79,7 @@ impl MvtSchemeParser {
         });
 
         let building_handler = MvtPropHandler::new("building", |handler| {
+            // TODO skip for certain zoom levels
             let height: i64 = handler.get_prop_value("height");
             Some(MapGeomObject {
                 id: -1,
@@ -178,11 +179,11 @@ impl MvtPropHandler {
 
     pub fn get_prop_value<T: Default>(&self, key: &'static str) -> T
     where
-        Option<T>: From<LocalMvtValue2>,
+        Option<T>: From<LocalMvtValue>,
     {
         self.map
             .get(key)
-            .and_then(|value| LocalMvtValue2(value.clone()).into())
+            .and_then(|value| LocalMvtValue(value.clone()).into())
             .unwrap_or_default()
     }
 }

--- a/map/src/tiles/mvt/mvt_scheme_parser.rs
+++ b/map/src/tiles/mvt/mvt_scheme_parser.rs
@@ -1,6 +1,8 @@
 use crate::tiles::mvt::mvt_parser::LocalMvtValue2;
 use fast_mvt::{MvtFeatureRef, MvtLayerRef, MvtValue};
-use osm::map::{MapGeomObject, MapGeometry};
+use osm::map::{
+    HighwayKind, LayerKind, LineKind, MapGeomObject, MapGeomObjectKind, MapGeometry, WayInfo,
+};
 use std::collections::HashMap;
 
 pub(crate) struct MvtSchemeParser {
@@ -10,15 +12,41 @@ pub(crate) struct MvtSchemeParser {
 impl MvtSchemeParser {
     pub fn new_map_tiler_v4() -> Self {
         let handlers = vec![MvtPropHandler::new("road", |handler| {
-            let layer: Option<i64> = handler.get_prop_value("layer");
-            let road_class: Option<String> = handler.get_prop_value("class");
-            let brunnel: Option<bool> = handler.get_prop_value("brunnel");
-            let ramp: Option<bool> = handler.get_prop_value("ramp");
+            let road_layer: i64 = handler.get_prop_value("layer");
+            let road_class: String = handler.get_prop_value("class");
+            let brunnel: String = handler.get_prop_value("brunnel");
+            let brunnel: bool = !brunnel.is_empty();
+            let ramp: bool = handler.get_prop_value("ramp");
 
-            
+            let mut highway_kind_name: Option<&str> = match road_class.as_str() {
+                "motorway" => Some("motorway"),
+                "primary" => Some("primary"),
+                "secondary" => Some("secondary"),
+                "tertiary" => Some("tertiary"),
+                "unclassified" => Some("unclassified"),
+                "residential" => Some("residential"),
+                "minor" => Some("residential"),
+                "service" => Some("service"),
+                "trunk" => Some("trunk"),
+                _ => None,
+            };
 
-            todo!("MapGeomObject impl");
-            // true
+            highway_kind_name.map(|highway_kind_name| {
+                let mut bb = highway_kind_name.to_string();
+                if ramp {
+                    bb = format!("{highway_kind_name}_link");
+                }
+                let highway_kind = HighwayKind::from_descr(bb.as_str()).unwrap();
+                MapGeomObject {
+                    id: -1,
+                    kind: MapGeomObjectKind::Way(WayInfo {
+                        line_kind: LineKind::Highway { kind: highway_kind },
+                        layer: if brunnel { road_layer as i32 } else { 0 },
+                        layer_kind: LayerKind::None,
+                        name_en: None,
+                    }),
+                }
+            })
         })];
         Self::new_from_handlers(handlers)
     }
@@ -57,14 +85,14 @@ impl MvtSchemeParser {
 
 struct MvtPropHandler<'a> {
     layer: &'static str,
-    builder: Box<dyn Fn(&Self) -> MapGeomObject>,
+    builder: Box<dyn Fn(&Self) -> Option<MapGeomObject>>,
     map: HashMap<String, MvtValue>,
 }
 
 impl<'a> MvtPropHandler<'a> {
     pub fn new<F>(layer: &'static str, builder: F) -> Self
     where
-        F: Fn(&Self) -> MapGeomObject + 'static,
+        F: Fn(&Self) -> Option<MapGeomObject> + 'static,
     {
         Self {
             layer,
@@ -93,18 +121,24 @@ impl<'a> MvtPropHandler<'a> {
         }
 
         let geom_obj = (self.builder)(&self);
-        let geom = geom_builder(feature);
-        geom.into_iter()
-            .map(|geometry| (geom_obj.clone(), geometry))
-            .collect()
+        geom_obj
+            .map(|geom_obj| {
+                let geom = geom_builder(feature);
+                geom.into_iter()
+                    .map(|geometry| (geom_obj.clone(), geometry))
+                    .collect()
+            })
+            .unwrap_or_default()
     }
 
-    pub fn get_prop_value<T>(&self, key: &'static str) -> Option<T>
+    pub fn get_prop_value<T: Default>(&self, key: &'static str) -> T
     where
         T: From<LocalMvtValue2>,
     {
         self.map
             .get(key)
-            .map(|value| LocalMvtValue2(value.clone()).into()) // TODO how to remove clone?
+            // FIXME how to remove clone?
+            .map(|value| LocalMvtValue2(value.clone()).into())
+            .unwrap_or_default()
     }
 }

--- a/map/src/tiles/mvt/mvt_scheme_parser.rs
+++ b/map/src/tiles/mvt/mvt_scheme_parser.rs
@@ -187,6 +187,7 @@ impl MvtPropHandler {
     {
         self.map
             .get(key)
+            // How to get rid of clone()?
             .and_then(|value| LocalMvtValue(value.clone()).into())
             .unwrap_or_default()
     }

--- a/map/src/tiles/mvt/mvt_scheme_parser.rs
+++ b/map/src/tiles/mvt/mvt_scheme_parser.rs
@@ -34,11 +34,11 @@ impl MvtSchemeParser {
             };
 
             highway_kind_name.and_then(|highway_kind_name| {
-                let mut bb = highway_kind_name.to_string();
+                let mut highway_tag = highway_kind_name.to_string();
                 if ramp {
-                    bb = format!("{highway_kind_name}_link");
+                    highway_tag = format!("{highway_kind_name}_link");
                 }
-                HighwayKind::from_descr(bb.as_str()).map(|kind| MapGeomObject {
+                HighwayKind::from_descr(highway_tag.as_str()).map(|kind| MapGeomObject {
                     id: -1,
                     kind: MapGeomObjectKind::Way(WayInfo {
                         line_kind: LineKind::Highway { kind },
@@ -115,17 +115,20 @@ impl MvtSchemeParser {
     where
         F: Fn(&MvtFeatureRef) -> Vec<MapGeometry<i32>>,
     {
-        let mut res = vec![];
-        for layer in layers {
-            if let Some(mut handler) = self.config.get(layer.name()).cloned() {
-                for feature in layer.features() {
-                    let data = handler.build(&feature, &geom_builder);
-                    res.extend(data);
-                }
-            }
-        }
-
-        res
+        let geom_builder_ref = &geom_builder;
+        layers
+            .filter_map(|layer| {
+                self.config
+                    .get(layer.name())
+                    .cloned()
+                    .map(|handler| (layer, handler))
+            })
+            .flat_map(|(layer, mut handler)| {
+                layer
+                    .features()
+                    .flat_map(move |feature| handler.build(&feature, geom_builder_ref))
+            })
+            .collect()
     }
 }
 

--- a/map/src/tiles/mvt/mvt_tile_store.rs
+++ b/map/src/tiles/mvt/mvt_tile_store.rs
@@ -17,6 +17,7 @@ struct TileMetersBounds {
 }
 
 pub(crate) struct MvtTileStore {
+    mvt_parser: MvtParser,
     client: reqwest::blocking::Client,
 }
 
@@ -33,7 +34,10 @@ impl MvtTileStore {
             .timeout(Duration::from_secs(10))
             .build()
             .unwrap();
-        Self { client }
+        Self {
+            mvt_parser: MvtParser::new(),
+            client
+        }
     }
     fn tile_id_to_mercator_meters(tx: u32, ty: u32, zoom: u32) -> TileMetersBounds {
         let num_tiles = (1 << zoom) as f64;
@@ -164,8 +168,7 @@ impl TilesProviderStore for MvtTileStore {
 
     fn load(&self, tile_key: &TileKey) -> Vec<(MapGeomObject, MapGeometry<f32>)> {
         let data = self.fetch_tile(tile_key.tile_x, tile_key.tile_y, tile_key.zoom_level).unwrap_or_default();
-        let mut parser = MvtParser::new();
-        parser.read_mvt_tile2(data.as_slice(), tile_key).unwrap_or_default()
+        self.mvt_parser.read_mvt_tile2(data.as_slice(), tile_key).unwrap_or_default()
         // MvtParser::read_mvt_tile(data.as_slice(), tile_key).unwrap_or_default()
     }
 }

--- a/map/src/tiles/mvt/mvt_tile_store.rs
+++ b/map/src/tiles/mvt/mvt_tile_store.rs
@@ -164,7 +164,9 @@ impl TilesProviderStore for MvtTileStore {
 
     fn load(&self, tile_key: &TileKey) -> Vec<(MapGeomObject, MapGeometry<f32>)> {
         let data = self.fetch_tile(tile_key.tile_x, tile_key.tile_y, tile_key.zoom_level).unwrap_or_default();
-        MvtParser::read_mvt_tile(data.as_slice(), tile_key).unwrap_or_default()
+        let mut parser = MvtParser::new();
+        parser.read_mvt_tile2(data.as_slice(), tile_key).unwrap_or_default()
+        // MvtParser::read_mvt_tile(data.as_slice(), tile_key).unwrap_or_default()
     }
 }
 

--- a/map/src/tiles/mvt/mvt_tile_store.rs
+++ b/map/src/tiles/mvt/mvt_tile_store.rs
@@ -168,7 +168,7 @@ impl TilesProviderStore for MvtTileStore {
 
     fn load(&self, tile_key: &TileKey) -> Vec<(MapGeomObject, MapGeometry<f32>)> {
         let data = self.fetch_tile(tile_key.tile_x, tile_key.tile_y, tile_key.zoom_level).unwrap_or_default();
-        self.mvt_parser.read_mvt_tile2(data.as_slice(), tile_key).unwrap_or_default()
+        self.mvt_parser.read_mvt_tile(data.as_slice(), tile_key).unwrap_or_default()
         // MvtParser::read_mvt_tile(data.as_slice(), tile_key).unwrap_or_default()
     }
 }

--- a/map/src/tiles/mvt/mvt_tile_store.rs
+++ b/map/src/tiles/mvt/mvt_tile_store.rs
@@ -169,7 +169,6 @@ impl TilesProviderStore for MvtTileStore {
     fn load(&self, tile_key: &TileKey) -> Vec<(MapGeomObject, MapGeometry<f32>)> {
         let data = self.fetch_tile(tile_key.tile_x, tile_key.tile_y, tile_key.zoom_level).unwrap_or_default();
         self.mvt_parser.read_mvt_tile(data.as_slice(), tile_key).unwrap_or_default()
-        // MvtParser::read_mvt_tile(data.as_slice(), tile_key).unwrap_or_default()
     }
 }
 

--- a/map/src/tiles/mvt/mvt_tile_store.rs
+++ b/map/src/tiles/mvt/mvt_tile_store.rs
@@ -35,7 +35,7 @@ impl MvtTileStore {
             .build()
             .unwrap();
         Self {
-            mvt_parser: MvtParser::new(),
+            mvt_parser: MvtParser::default(),
             client
         }
     }


### PR DESCRIPTION
## Summary
* Introduced `MvtSchemeParser` as a configurable way to parse MVT schemas(MapTiler v4 for now).