### PR TITLE
MVT: fix polygon interiors, labels, and route scaling

### DIFF
--- a/map/src/feature_processor.rs
+++ b/map/src/feature_processor.rs
@@ -171,7 +171,7 @@ impl FeatureProcessor for ShashlikFeatureProcessor {
 
             // fyi, we need to close the building path to properly build a closed stroke
             // also if interiors are not empty!
-            let end_with_closing = matches!(kind, MapGeomObjectKind::Building {..}) || !interiors.is_empty();
+            let end_with_closing = matches!(kind, MapGeomObjectKind::Building(_)) || !interiors.is_empty();
             path_builder.end(end_with_closing);
 
             for interior in interiors {

--- a/map/src/feature_processor.rs
+++ b/map/src/feature_processor.rs
@@ -152,8 +152,8 @@ impl FeatureProcessor for ShashlikFeatureProcessor {
     fn process_line(
         &self,
         geometry_data: &mut Vec<GeometryData>,
-        line: LineString,
-        interiors: Vec<LineString>,
+        line: LineString<f32>,
+        interiors: Vec<LineString<f32>>,
         kind: MapGeomObjectKind,
         line_text_map: &mut HashMap<String, i32>,
         zoom_level: i32,
@@ -163,10 +163,10 @@ impl FeatureProcessor for ShashlikFeatureProcessor {
         let line = line.0;
         if line.len() >= 2 {
             let mut path_builder = Path::builder();
-            path_builder.begin(point(line[0].x as f32, line[0].y as f32));
+            path_builder.begin(point(line[0].x, line[0].y));
 
             for &p in line[1..].iter() {
-                path_builder.line_to(point(p.x as f32, p.y as f32));
+                path_builder.line_to(point(p.x, p.y));
             }
 
             // fyi, we need to close the building path to properly build a closed stroke
@@ -176,10 +176,10 @@ impl FeatureProcessor for ShashlikFeatureProcessor {
 
             for interior in interiors {
                 if let Some(first_point) = interior.0.first() {
-                    path_builder.begin(point(first_point.x as f32, first_point.y as f32));
+                    path_builder.begin(point(first_point.x, first_point.y));
 
                     for p in interior.0.iter().skip(1) {
-                        path_builder.line_to(point(p.x as f32, p.y as f32));
+                        path_builder.line_to(point(p.x, p.y));
                     }
 
                     path_builder.end(true);
@@ -315,7 +315,7 @@ impl FeatureProcessor for ShashlikFeatureProcessor {
                                 22.0 * dpi_scale,
                                 LineData::new(line
                                     .iter()
-                                    .map(|item| DVec3::new(item.x, item.y, 0.0))
+                                    .map(|item| DVec3::new(item.x as f64, item.y as f64, 0.0))
                                     .collect())
                             )));
                         }

--- a/map/src/feature_processor.rs
+++ b/map/src/feature_processor.rs
@@ -153,6 +153,7 @@ impl FeatureProcessor for ShashlikFeatureProcessor {
         &self,
         geometry_data: &mut Vec<GeometryData>,
         line: LineString,
+        interiors: Vec<LineString>,
         kind: MapGeomObjectKind,
         line_text_map: &mut HashMap<String, i32>,
         zoom_level: i32,
@@ -169,8 +170,21 @@ impl FeatureProcessor for ShashlikFeatureProcessor {
             }
 
             // fyi, we need to close the building path to properly build a closed stroke
-            let end_with_closing = matches!(kind, MapGeomObjectKind::Building {..});
+            // also if interiors are not empty!
+            let end_with_closing = matches!(kind, MapGeomObjectKind::Building {..}) || !interiors.is_empty();
             path_builder.end(end_with_closing);
+
+            for interior in interiors {
+                if let Some(first_point) = interior.0.first() {
+                    path_builder.begin(point(first_point.x as f32, first_point.y as f32));
+
+                    for p in interior.0.iter().skip(1) {
+                        path_builder.line_to(point(p.x as f32, p.y as f32));
+                    }
+
+                    path_builder.end(true);
+                }
+            }
 
             if let Some((style_id, layer_level, geometry_type, name)) = match &kind {
                 MapGeomObjectKind::Way(info) => match info.line_kind {

--- a/map/src/tiles/default_tiles_provider.rs
+++ b/map/src/tiles/default_tiles_provider.rs
@@ -153,10 +153,9 @@ impl<FP: FeatureProcessor + 'static> DefaultTilesProvider<FP> {
                     let is_visible = !is_building || is_visible;
 
                     if is_visible {
-                        let lines = poly.into_inner();
-                        let mut line = lines.0;
+                        let (mut line, interiors) = poly.into_inner();
                         let interiors = if is_water {
-                            lines.1
+                            interiors
                         } else {
                             vec![]
                         };

--- a/map/src/tiles/default_tiles_provider.rs
+++ b/map/src/tiles/default_tiles_provider.rs
@@ -2,11 +2,11 @@ use crate::tiles::tile_data::TileData;
 use crate::tiles::tiles_provider::{MercatorConverter, TilesMessage, TilesProvider, TilesProviderStore};
 use futures::{Stream};
 use futures::channel::mpsc::{UnboundedSender, unbounded};
-use geo::{Area, Convert, MapCoordsInPlace};
+use geo::{Area, Convert};
 use geo::Winding;
 use geo_types::{coord, Coord, LineString, Rect};
 use log::error;
-use osm::map::{MapGeomObject, MapGeomObjectKind, MapGeometry, MapPointInfo, NatureKind};
+use osm::map::{MapGeomObject, MapGeomObjectKind, MapGeometry, MapPointInfo};
 use osm::tiles::{TileKey, TileStore};
 use rayon::iter::IntoParallelRefIterator;
 use rayon::iter::ParallelIterator;
@@ -33,8 +33,8 @@ pub trait FeatureProcessor: Send + Sync {
     fn process_line(
         &self,
         geometry_data: &mut Vec<GeometryData>,
-        line: LineString,
-        interiors: Vec<LineString>,
+        line: LineString<f32>,
+        interiors: Vec<LineString<f32>>,
         kind: MapGeomObjectKind,
         line_text_map: &mut HashMap<String, i32>,
         zoom_level: i32,
@@ -156,7 +156,7 @@ impl<FP: FeatureProcessor + 'static> DefaultTilesProvider<FP> {
                         let lines = poly.into_inner();
                         let mut line = lines.0;
                         let interiors = if is_water {
-                            lines.1.iter().map(|line| line.convert()).collect()
+                            lines.1
                         } else {
                             vec![]
                         };
@@ -169,7 +169,7 @@ impl<FP: FeatureProcessor + 'static> DefaultTilesProvider<FP> {
 
                         feature_processor.process_line(
                             &mut geometry_data,
-                            line.convert(),
+                            line,
                             interiors,
                             obj_type.kind,
                             &mut line_text_map,

--- a/map/src/tiles/default_tiles_provider.rs
+++ b/map/src/tiles/default_tiles_provider.rs
@@ -2,11 +2,11 @@ use crate::tiles::tile_data::TileData;
 use crate::tiles::tiles_provider::{MercatorConverter, TilesMessage, TilesProvider, TilesProviderStore};
 use futures::{Stream};
 use futures::channel::mpsc::{UnboundedSender, unbounded};
-use geo::{Area, Convert};
+use geo::{Area, Convert, MapCoordsInPlace};
 use geo::Winding;
 use geo_types::{coord, Coord, LineString, Rect};
 use log::error;
-use osm::map::{MapGeomObject, MapGeomObjectKind, MapGeometry, MapPointInfo};
+use osm::map::{MapGeomObject, MapGeomObjectKind, MapGeometry, MapPointInfo, NatureKind};
 use osm::tiles::{TileKey, TileStore};
 use rayon::iter::IntoParallelRefIterator;
 use rayon::iter::ParallelIterator;
@@ -34,6 +34,7 @@ pub trait FeatureProcessor: Send + Sync {
         &self,
         geometry_data: &mut Vec<GeometryData>,
         line: LineString,
+        interiors: Vec<LineString>,
         kind: MapGeomObjectKind,
         line_text_map: &mut HashMap<String, i32>,
         zoom_level: i32,
@@ -134,6 +135,7 @@ impl<FP: FeatureProcessor + 'static> DefaultTilesProvider<FP> {
                     feature_processor.process_line(
                         &mut geometry_data,
                         line.convert(),
+                        vec![],
                         obj_type.kind,
                         &mut line_text_map,
                         zoom_level,
@@ -142,6 +144,7 @@ impl<FP: FeatureProcessor + 'static> DefaultTilesProvider<FP> {
                 }
                 MapGeometry::Poly(poly) => {
                     let is_building = matches!(obj_type.kind, MapGeomObjectKind::Building(_));
+                    let is_water = matches!(obj_type.kind, MapGeomObjectKind::Nature(Water));
                     let is_visible = !cfg!(target_os = "linux")
                         || zoom_level == MAX_ZOOM_LEVEL
                         // reduce amount of buildings for linux
@@ -150,7 +153,13 @@ impl<FP: FeatureProcessor + 'static> DefaultTilesProvider<FP> {
                     let is_visible = !is_building || is_visible;
 
                     if is_visible {
-                        let mut line = poly.into_inner().0;
+                        let lines = poly.into_inner();
+                        let mut line = lines.0;
+                        let interiors = if is_water {
+                            lines.1.iter().map(|line| line.convert()).collect()
+                        } else {
+                            vec![]
+                        };
 
                         if is_building {
                             // the winding might not be the same for building lines,
@@ -161,6 +170,7 @@ impl<FP: FeatureProcessor + 'static> DefaultTilesProvider<FP> {
                         feature_processor.process_line(
                             &mut geometry_data,
                             line.convert(),
+                            interiors,
                             obj_type.kind,
                             &mut line_text_map,
                             zoom_level,

--- a/map/src/tiles/mvt/mvt_scheme_parser.rs
+++ b/map/src/tiles/mvt/mvt_scheme_parser.rs
@@ -82,7 +82,7 @@ impl MvtSchemeParser {
             // TODO skip for certain zoom levels
             let height: i64 = handler.get_prop_value("height");
             let underground: bool = handler.get_prop_value("underground");
-            (!underground).then(|| MapGeomObject {
+            (!underground).then_some(MapGeomObject {
                 id: -1,
                 // fyi, 3 - koef to convert map tiler height to osm levels, 2 - feature processor multiplier
                 kind: MapGeomObjectKind::Building(((height / (3 * 2)) as u16).clamp(0, 100)),
@@ -163,17 +163,15 @@ impl MvtSchemeParser {
 
         let country_border_handler = MvtPropHandler::new("country_border", |handler| {
             let maritime: bool = handler.get_prop_value("maritime");
-            (!maritime).then(|| {
-                MapGeomObject {
-                    id: -1,
-                    kind: MapGeomObjectKind::AdminLine,
-                }
+            (!maritime).then_some(MapGeomObject {
+                id: -1,
+                kind: MapGeomObjectKind::AdminLine,
             })
         });
 
         let railway_handler = MvtPropHandler::new("railway", |handler| {
             let class: String = handler.get_prop_value("class");
-            (class == "rail" || class == "monorail").then(|| MapGeomObject {
+            (class == "rail" || class == "monorail").then_some(MapGeomObject {
                 id: -1,
                 kind: MapGeomObjectKind::Way(WayInfo {
                     line_kind: LineKind::Railway {

--- a/map/src/tiles/mvt/mvt_scheme_parser.rs
+++ b/map/src/tiles/mvt/mvt_scheme_parser.rs
@@ -143,12 +143,13 @@ impl MvtSchemeParser {
         });
 
         let city_country_label_handler = |handler: &MvtPropHandler| {
-            let name: String = handler.get_prop_value("name:en");
+            let name_en: String = handler.get_prop_value("name:en");
+            let name: String = handler.get_prop_value("name");
 
             Some(MapGeomObject {
                 id: -1,
                 kind: MapGeomObjectKind::Poi(MapPointInfo {
-                    text: name,
+                    text: if name_en.is_empty() { name } else { name_en },
                     kind: MapPointObjectKind::PopArea(PopAreaInfo {
                         level: 0,
                         population: 0,
@@ -160,10 +161,13 @@ impl MvtSchemeParser {
         let country_label_handler =
             MvtPropHandler::new("country_label", city_country_label_handler);
 
-        let country_border_handler = MvtPropHandler::new("country_border", |_| {
-            Some(MapGeomObject {
-                id: -1,
-                kind: MapGeomObjectKind::AdminLine,
+        let country_border_handler = MvtPropHandler::new("country_border", |handler| {
+            let maritime: bool = handler.get_prop_value("maritime");
+            (!maritime).then(|| {
+                MapGeomObject {
+                    id: -1,
+                    kind: MapGeomObjectKind::AdminLine,
+                }
             })
         });
 

--- a/renderer/src/shaders/shape_shader.wgsl
+++ b/renderer/src/shaders/shape_shader.wgsl
@@ -136,7 +136,7 @@ fn vs_main_route(
 
     var pointPos = modelpos.xyz;
     if(with_normal) {
-        var normal_scale = max(camera_scale, 0.75) - 1.0;
+        var normal_scale = max(camera_scale, 0.75) * 0.5;
         if(model.instance_index % 2 == 0) {
             if(normal_scale < 0.0) {
                 normal_scale /= route_inflate_factor;


### PR DESCRIPTION
## Summary
* better support for polygon's interiors(for water)
* fixed cities/countries labels
* removed maritime borders
* fixed route scaling