### PR TITLE
TechDebt. BindGroup cache

### DIFF
--- a/renderer-gpu/src/bind_group_cache.rs
+++ b/renderer-gpu/src/bind_group_cache.rs
@@ -19,6 +19,7 @@ impl BindGroupKey {
 pub(crate) struct BindGroupCache {
     device: Device,
     bind_groups: FxHashMap<BindGroupKey, BindGroup>,
+    accessed: bool
 }
 
 impl BindGroupCache {
@@ -26,6 +27,7 @@ impl BindGroupCache {
         Self {
             bind_groups: FxHashMap::default(),
             device: device.clone(),
+            accessed: false
         }
     }
 
@@ -34,8 +36,17 @@ impl BindGroupCache {
         bind_group_key: BindGroupKey,
         action: impl FnOnce(&Device) -> BindGroup,
     ) -> &BindGroup {
+        self.accessed = true;
         self.bind_groups
             .entry(bind_group_key)
             .or_insert_with(|| action(&self.device))
+    }
+
+    /// If the cache hasn't been accessed between frames, clear it!
+    pub fn clear_if_needed(&mut self) {
+        if !self.accessed && !self.bind_groups.is_empty() {
+            self.bind_groups.clear();
+        }
+        self.accessed = false;
     }
 }

--- a/renderer-gpu/src/bind_group_cache.rs
+++ b/renderer-gpu/src/bind_group_cache.rs
@@ -1,14 +1,15 @@
 use rustc_hash::FxHashMap;
 use wgpu::{BindGroup, Device};
+use crate::mesh_buffers::UniqueBufferId;
 
 #[derive(Eq, PartialEq, Hash)]
 pub(crate) struct BindGroupKey {
     layout_id: usize,
-    inner: Vec<usize>,
+    inner: Vec<UniqueBufferId>,
 }
 
 impl BindGroupKey {
-    pub fn new(layout_id: usize, buffer_ids: &[usize]) -> Self {
+    pub fn new(layout_id: UniqueBufferId, buffer_ids: &[usize]) -> Self {
         let mut ids = buffer_ids.to_vec();
         ids.sort();
         BindGroupKey { layout_id, inner: ids }

--- a/renderer-gpu/src/bind_group_cache.rs
+++ b/renderer-gpu/src/bind_group_cache.rs
@@ -1,0 +1,40 @@
+use rustc_hash::FxHashMap;
+use wgpu::{BindGroup, Device};
+
+#[derive(Eq, PartialEq, Hash)]
+pub(crate) struct BindGroupKey {
+    layout_id: usize,
+    inner: Vec<usize>,
+}
+
+impl BindGroupKey {
+    pub fn new(layout_id: usize, buffer_ids: &[usize]) -> Self {
+        let mut ids = buffer_ids.to_vec();
+        ids.sort();
+        BindGroupKey { layout_id, inner: ids }
+    }
+}
+
+pub(crate) struct BindGroupCache {
+    device: Device,
+    bind_groups: FxHashMap<BindGroupKey, BindGroup>,
+}
+
+impl BindGroupCache {
+    pub fn new(device: &Device) -> Self {
+        Self {
+            bind_groups: FxHashMap::default(),
+            device: device.clone(),
+        }
+    }
+
+    pub fn get_bind_group_or_create(
+        &mut self,
+        bind_group_key: BindGroupKey,
+        action: impl FnOnce(&Device) -> BindGroup,
+    ) -> &BindGroup {
+        self.bind_groups
+            .entry(bind_group_key)
+            .or_insert_with(|| action(&self.device))
+    }
+}

--- a/renderer-gpu/src/lib.rs
+++ b/renderer-gpu/src/lib.rs
@@ -60,6 +60,7 @@ pub mod render_config;
 
 pub(crate) mod texture_view_resources;
 mod mesh_buffers;
+pub(crate) mod bind_group_cache;
 
 pub struct GpuRenderer {
     render_config: RenderConfig,

--- a/renderer-gpu/src/mesh/mod.rs
+++ b/renderer-gpu/src/mesh/mod.rs
@@ -1,8 +1,8 @@
 use crate::global_context::GlobalContext;
 use bytemuck::Pod;
 use std::marker::PhantomData;
-use wgpu::util::DeviceExt;
 use wgpu::Buffer;
+use wgpu::util::DeviceExt;
 
 pub mod mesh;
 pub mod mesh_instance_input;
@@ -34,12 +34,15 @@ impl<T: Pod> InstanceBuffer<T> {
         if data_len <= self.max_length
             && let Some(buffer) = self.buffer.as_ref()
         {
-            let queue = global_context.queue();
-            queue.write_buffer(buffer, 0, bytemuck::cast_slice(data.as_slice()));
-            // FIXME write_buffer_with doesn't work as expected, why?
-            // if let Some(mut buf_view) = queue.write_buffer_with(buffer, 0, data_size) {
-            //     buf_view.copy_from_slice(data);
-            // }
+            // write only non-zero data, if zero then only write once
+            if data_len != 0 || data_len != self.length {
+                let queue = global_context.queue();
+                queue.write_buffer(buffer, 0, bytemuck::cast_slice(data.as_slice()));
+                // FIXME write_buffer_with doesn't work as expected, why?
+                // if let Some(mut buf_view) = queue.write_buffer_with(buffer, 0, data_size) {
+                //     buf_view.copy_from_slice(data);
+                // }
+            }
         } else {
             let device = global_context.device();
             self.buffer = Some(

--- a/renderer-gpu/src/mesh/positioned_mesh.rs
+++ b/renderer-gpu/src/mesh/positioned_mesh.rs
@@ -114,17 +114,14 @@ impl<T: MeshInstanceInput> PositionedMesh<T> {
                 });
 
                 if let Some(instance_buffer) = self.instance_buffer.buffer.as_ref() {
-                    self.mesh_buffers = MeshBuffers {
-                        instance_buffer: Some(instance_buffer.clone()),
-                        culled_buffer: Some(culled_buffer),
-                        instance_args_buffer: Some(indirect_args),
-                    };
+                    self.mesh_buffers = MeshBuffers::builder()
+                        .with_instance_buffer(Some(instance_buffer.clone()))
+                        .with_culled_and_args_buffer(Some(culled_buffer), Some(indirect_args))
                 }
 
             } else {
-                self.mesh_buffers.instance_buffer = self.instance_buffer.buffer.clone();
-                self.mesh_buffers.culled_buffer = None;
-                self.mesh_buffers.instance_args_buffer = None;
+                self.mesh_buffers = MeshBuffers::builder()
+                    .with_instance_buffer(self.instance_buffer.buffer.clone())
             }
         }
     }
@@ -133,7 +130,7 @@ impl<T: MeshInstanceInput> PositionedMesh<T> {
         &self,
         compute_pass: &mut ComputePass,
     ) {
-        if self.mesh_buffers.instance_buffer.is_some() {
+        if self.mesh_buffers.instance_buffer().is_some() {
             // workgroups are batches by 64/128
             let instance_buffer_length = self.get_instance_buffer_length() as u32;
             let mut x = instance_buffer_length / 64;
@@ -158,7 +155,7 @@ impl<T: MeshInstanceInput> PositionedMesh<T> {
         render_pass: &mut RenderPass,
         disable_skip_mesh_feature: bool,
     ) {
-        let instances_args_buffer = self.mesh_buffers.instance_args_buffer.as_ref();
+        let instances_args_buffer = self.mesh_buffers.args_buffer();
         let instance_count = self.get_instance_buffer_length();
         self.mesh.render_instanced(
             render_pass,

--- a/renderer-gpu/src/mesh_buffers.rs
+++ b/renderer-gpu/src/mesh_buffers.rs
@@ -50,24 +50,24 @@ impl MeshBuffers {
 }
 
 static BUFFER_ID: AtomicUsize = AtomicUsize::new(0);
+pub(crate) type UniqueBufferId = usize;
 
 #[derive(Clone)]
 pub struct BufferWithId {
-    id: usize,
+    id: UniqueBufferId,
     buffer: Buffer,
 }
 
 impl BufferWithId {
     pub fn new(buffer: Buffer) -> Self {
         let id = BUFFER_ID.fetch_add(1, Ordering::Relaxed);
-        // println!("buf id = {id}");
         Self {
             id,
             buffer,
         }
     }
 
-    pub fn id(&self) -> usize {
+    pub fn id(&self) -> UniqueBufferId {
         self.id
     }
     pub fn buffer(&self) -> &Buffer {

--- a/renderer-gpu/src/mesh_buffers.rs
+++ b/renderer-gpu/src/mesh_buffers.rs
@@ -1,17 +1,82 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
 use wgpu::Buffer;
 
 #[derive(Clone, Default)]
 pub struct MeshBuffers {
-    pub instance_buffer: Option<Buffer>,
-    pub culled_buffer: Option<Buffer>,
-    pub instance_args_buffer: Option<Buffer>,
+    instance_buffer: Option<BufferWithId>,
+    culled_buffer: Option<BufferWithId>,
+    instance_args_buffer: Option<BufferWithId>,
 }
 
 impl MeshBuffers {
-    pub fn with_instance_buffer(buffer: Option<Buffer>) -> Self {
-        Self {
-            instance_buffer: buffer,
-            ..Default::default()
-        }
+    pub fn builder() -> MeshBuffers {
+        Self::default()
+    }
+
+    pub fn with_instance_buffer(mut self, buffer: Option<Buffer>) -> Self {
+        self.instance_buffer = buffer.map(Into::into);
+        self
+    }
+
+    pub fn with_culled_and_args_buffer(mut self, culled_buffer: Option<Buffer>, args_buffer: Option<Buffer>) -> Self {
+        self.culled_buffer = culled_buffer.map(Into::into);
+        self.instance_args_buffer = args_buffer.map(Into::into);
+        self
+    }
+
+    pub fn instance_buffer(&self) -> Option<&Buffer> {
+        self.instance_buffer.as_ref().map(|id| &id.buffer)
+    }
+
+    pub fn culled_buffer(&self) -> Option<&Buffer> {
+        self.culled_buffer.as_ref().map(|id| &id.buffer)
+    }
+
+    pub fn args_buffer(&self) -> Option<&Buffer> {
+        self.instance_args_buffer.as_ref().map(|id| &id.buffer)
+    }
+
+    pub fn instance_buffer_with_id(&self) -> Option<&BufferWithId> {
+        self.instance_buffer.as_ref()
+    }
+
+    pub fn culled_buffer_with_id(&self) -> Option<&BufferWithId> {
+        self.culled_buffer.as_ref()
+    }
+
+    pub fn args_buffer_with_id(&self) -> Option<&BufferWithId> {
+        self.instance_args_buffer.as_ref()
     }
 }
+
+static BUFFER_ID: AtomicUsize = AtomicUsize::new(0);
+
+#[derive(Clone)]
+pub struct BufferWithId {
+    id: usize,
+    buffer: Buffer,
+}
+
+impl BufferWithId {
+    pub fn new(buffer: Buffer) -> Self {
+        let id = BUFFER_ID.fetch_add(1, Ordering::Relaxed);
+        Self {
+            id,
+            buffer,
+        }
+    }
+
+    pub fn id(&self) -> usize {
+        self.id
+    }
+    pub fn buffer(&self) -> &Buffer {
+        &self.buffer
+    }
+}
+
+impl From<Buffer> for BufferWithId {
+    fn from(value: Buffer) -> Self {
+        BufferWithId::new(value)
+    }
+}
+

--- a/renderer-gpu/src/mesh_buffers.rs
+++ b/renderer-gpu/src/mesh_buffers.rs
@@ -60,6 +60,7 @@ pub struct BufferWithId {
 impl BufferWithId {
     pub fn new(buffer: Buffer) -> Self {
         let id = BUFFER_ID.fetch_add(1, Ordering::Relaxed);
+        // println!("buf id = {id}");
         Self {
             id,
             buffer,

--- a/renderer-gpu/src/mesh_layers/general_mesh_layer.rs
+++ b/renderer-gpu/src/mesh_layers/general_mesh_layer.rs
@@ -144,7 +144,7 @@ impl<P: RenderPipeline> BaseMeshLayer for GeneralMeshLayer<P> {
 
             self.render_pipeline.setup_compute(&mut compute_pass, global_context);
             self.render_data_holder.run_mut_action(|mesh| {
-                self.render_pipeline.compute_mesh(&mut compute_pass, mesh.get_mesh_buffers(), global_context);
+                self.render_pipeline.compute_mesh(&mut compute_pass, mesh.get_mesh_buffers());
                 mesh.compute_instanced(&mut compute_pass);
             });
         }
@@ -166,7 +166,7 @@ impl<P: RenderPipeline> BaseMeshLayer for GeneralMeshLayer<P> {
             self.render_pipeline.setup_render(render_pass, global_context);
 
             self.render_data_holder.run_mut_action(|mesh| {
-                self.render_pipeline.render_mesh(render_pass, mesh.get_mesh_buffers(), global_context);
+                self.render_pipeline.render_mesh(render_pass, mesh.get_mesh_buffers());
                 mesh.render_instanced(render_pass, self.disable_skip_mesh_feature);
             });
         }

--- a/renderer-gpu/src/mesh_layers/ortho_mesh_layer.rs
+++ b/renderer-gpu/src/mesh_layers/ortho_mesh_layer.rs
@@ -171,7 +171,7 @@ impl<P: RenderPipeline + WithTexture> BaseMeshLayer for OrthoMeshLayer<P> {
                 render_pass.set_bind_group(1, texture_bind_group, &[]);
             }
 
-            self.render_pipeline.render_mesh(render_pass, &self.mesh_buffers, global_context);
+            self.render_pipeline.render_mesh(render_pass, &self.mesh_buffers);
             let instance_count = self.instance_buffer.length;
             mesh.render_instanced(render_pass, instance_count, false, None);
         }

--- a/renderer-gpu/src/mesh_layers/ortho_mesh_layer.rs
+++ b/renderer-gpu/src/mesh_layers/ortho_mesh_layer.rs
@@ -123,11 +123,8 @@ impl<P: RenderPipeline + WithTexture> OrthoMeshLayer<P> {
 
         self.instance_buffer
             .update("quad_instance_buffer", global_context, &vec![attr]);
-        self.mesh_buffers = MeshBuffers {
-            instance_buffer: self.instance_buffer.buffer.clone(),
-            culled_buffer: None,
-            instance_args_buffer: None,
-        }
+        self.mesh_buffers = MeshBuffers::builder()
+            .with_instance_buffer(self.instance_buffer.buffer.clone())
     }
 }
 

--- a/renderer-gpu/src/mesh_layers/screen_shape_layer.rs
+++ b/renderer-gpu/src/mesh_layers/screen_shape_layer.rs
@@ -141,7 +141,7 @@ impl<P: RenderPipeline> BaseMeshLayer for ScreenShapeLayer<P> {
             self.render_pipeline.setup_render(render_pass, global_context);
 
             self.meshes.iter().for_each(|(_, (mesh, instance_buf, mesh_buffers))| {
-                self.render_pipeline.render_mesh(render_pass, mesh_buffers, global_context);
+                self.render_pipeline.render_mesh(render_pass, mesh_buffers);
                 let instance_count = instance_buf.length;
                 mesh.render_instanced(render_pass, instance_count, false, None);
             });

--- a/renderer-gpu/src/mesh_layers/screen_shape_layer.rs
+++ b/renderer-gpu/src/mesh_layers/screen_shape_layer.rs
@@ -141,9 +141,11 @@ impl<P: RenderPipeline> BaseMeshLayer for ScreenShapeLayer<P> {
             self.render_pipeline.setup_render(render_pass, global_context);
 
             self.meshes.iter().for_each(|(_, (mesh, instance_buf, mesh_buffers))| {
-                self.render_pipeline.render_mesh(render_pass, mesh_buffers);
                 let instance_count = instance_buf.length;
-                mesh.render_instanced(render_pass, instance_count, false, None);
+                if instance_count > 0 {
+                    self.render_pipeline.render_mesh(render_pass, mesh_buffers);
+                    mesh.render_instanced(render_pass, instance_count, false, None);
+                }
             });
         }
     }

--- a/renderer-gpu/src/mesh_layers/screen_shape_layer.rs
+++ b/renderer-gpu/src/mesh_layers/screen_shape_layer.rs
@@ -127,7 +127,7 @@ impl<P: RenderPipeline> BaseMeshLayer for ScreenShapeLayer<P> {
                     global_context,
                     &attrs,
                 );
-                *mesh_buffers = MeshBuffers::with_instance_buffer(instance_buffer.buffer.clone());
+                *mesh_buffers = MeshBuffers::builder().with_instance_buffer(instance_buffer.buffer.clone());
             });
     }
 

--- a/renderer-gpu/src/pipelines/mod.rs
+++ b/renderer-gpu/src/pipelines/mod.rs
@@ -23,9 +23,9 @@ pub trait RenderPipeline {
 
     fn setup_compute(&mut self, _compute_pass: &mut ComputePass, _global_context: &GlobalContext) {}
     fn compute_mesh(&mut self, _compute_pass: &mut ComputePass,
-                    _mesh: &MeshBuffers, _global_context: &mut GlobalContext) {}
+                    _mesh: &MeshBuffers) {}
     fn setup_render(&mut self, render_pass: &mut RenderPass, global_context: &GlobalContext);
-    fn render_mesh(&mut self, render_pass: &mut RenderPass, mesh_buffers: &MeshBuffers, _global_context: &mut GlobalContext) {
+    fn render_mesh(&mut self, render_pass: &mut RenderPass, mesh_buffers: &MeshBuffers) {
         // by default all instances go to vertex buffer slot 1
         if let Some(buffer) = mesh_buffers.instance_buffer() {
             render_pass.set_vertex_buffer(1, buffer.slice(..));

--- a/renderer-gpu/src/pipelines/mod.rs
+++ b/renderer-gpu/src/pipelines/mod.rs
@@ -23,9 +23,9 @@ pub trait RenderPipeline {
 
     fn setup_compute(&mut self, _compute_pass: &mut ComputePass, _global_context: &GlobalContext) {}
     fn compute_mesh(&mut self, _compute_pass: &mut ComputePass,
-                    _mesh: &MeshBuffers, _global_context: &GlobalContext) {}
+                    _mesh: &MeshBuffers, _global_context: &mut GlobalContext) {}
     fn setup_render(&mut self, render_pass: &mut RenderPass, global_context: &GlobalContext);
-    fn render_mesh(&mut self, render_pass: &mut RenderPass, mesh_buffers: &MeshBuffers, _global_context: &GlobalContext) {
+    fn render_mesh(&mut self, render_pass: &mut RenderPass, mesh_buffers: &MeshBuffers, _global_context: &mut GlobalContext) {
         // by default all instances go to vertex buffer slot 1
         if let Some(buffer) = mesh_buffers.instance_buffer() {
             render_pass.set_vertex_buffer(1, buffer.slice(..));

--- a/renderer-gpu/src/pipelines/mod.rs
+++ b/renderer-gpu/src/pipelines/mod.rs
@@ -27,7 +27,7 @@ pub trait RenderPipeline {
     fn setup_render(&mut self, render_pass: &mut RenderPass, global_context: &GlobalContext);
     fn render_mesh(&mut self, render_pass: &mut RenderPass, mesh_buffers: &MeshBuffers, _global_context: &GlobalContext) {
         // by default all instances go to vertex buffer slot 1
-        if let Some(buffer) = mesh_buffers.instance_buffer.as_ref() {
+        if let Some(buffer) = mesh_buffers.instance_buffer() {
             render_pass.set_vertex_buffer(1, buffer.slice(..));
         }
     }

--- a/renderer-gpu/src/pipelines/shape_pipeline.rs
+++ b/renderer-gpu/src/pipelines/shape_pipeline.rs
@@ -164,6 +164,14 @@ impl ShapePipeline {
 impl RenderPipeline for ShapePipeline {
     type InstanceInputType = ShapeInstanceInput;
 
+    fn setup_compute(&mut self, _compute_pass: &mut ComputePass, _global_context: &GlobalContext) {
+        // we call it every frame to clear internal bind group cache for indirect buffers
+        if self.indirect {
+            self.bind_group_cache.clear_if_needed();
+        }
+    }
+
+
     fn compute_mesh(&mut self,
                     compute_pass: &mut ComputePass,
                     mesh_buffers: &MeshBuffers) {

--- a/renderer-gpu/src/pipelines/shape_pipeline.rs
+++ b/renderer-gpu/src/pipelines/shape_pipeline.rs
@@ -166,8 +166,7 @@ impl RenderPipeline for ShapePipeline {
 
     fn compute_mesh(&mut self,
                     compute_pass: &mut ComputePass,
-                    mesh_buffers: &MeshBuffers,
-                    global_context: &mut GlobalContext) {
+                    mesh_buffers: &MeshBuffers) {
         if self.indirect {
             if let Some(instance_args_buffer) = mesh_buffers.args_buffer_with_id() &&
                 let Some(culled_buffer) = mesh_buffers.culled_buffer_with_id() &&
@@ -217,7 +216,7 @@ impl RenderPipeline for ShapePipeline {
         }
     }
 
-    fn render_mesh(&mut self, render_pass: &mut RenderPass, mesh_buffers: &MeshBuffers, global_context: &mut GlobalContext) {
+    fn render_mesh(&mut self, render_pass: &mut RenderPass, mesh_buffers: &MeshBuffers) {
         if self.indirect && let Some(instance_buffer) = mesh_buffers.instance_buffer_with_id()
             && let Some(culled_buffer) = mesh_buffers.culled_buffer_with_id() {
             let instance_bind_group = self.bind_group_cache.get_bind_group_or_create(

--- a/renderer-gpu/src/pipelines/shape_pipeline.rs
+++ b/renderer-gpu/src/pipelines/shape_pipeline.rs
@@ -6,14 +6,16 @@ use crate::vertex_attrs::{ShapeInstanceInput, ShapeVertex, VertexAttrib};
 use log::error;
 use std::borrow::Cow;
 use wesl::include_wesl;
-use wgpu::{BindGroup, BindGroupLayout, Buffer, CompareFunction, ComputePass, ComputePipeline, ComputePipelineDescriptor, RenderPass, ShaderModuleDescriptor, ShaderSource, ShaderStages};
+use wgpu::{BindGroup, BindGroupLayout, Buffer, CompareFunction, ComputePass, ComputePipeline, ComputePipelineDescriptor, Device, RenderPass, ShaderModuleDescriptor, ShaderSource, ShaderStages};
+use crate::bind_group_cache::{BindGroupCache, BindGroupKey};
 
 pub struct ShapePipeline {
     mesh_pipeline: MeshPipeline,
     vs_func_name: Option<&'static str>,
-    indirect_instances_layout: BindGroupLayout,
+    bind_group_cache: BindGroupCache,
+    indirect_render_instances_layout: BindGroupLayout,
     indirect_compute_instances_layout: BindGroupLayout,
-    indirect_instances_args_layout: BindGroupLayout,
+    indirect_compute_instances_args_layout: BindGroupLayout,
     culling_compute_pipeline: ComputePipeline,
     reset_culling_compute_pipeline: ComputePipeline,
     indirect: bool,
@@ -23,12 +25,16 @@ pub struct ShapePipeline {
 impl ShapePipeline {
     const SHADER_STYLE_GROUP_INDEX: u32 = 1;
 
+    const COMPUTE_LAYOUT_ID: usize = 0;
+    const RENDER_LAYOUT_ID: usize = 1;
+
+
     pub fn new(global_context: &GlobalContext, vs_func_name: Option<&'static str>,
                indirect: bool,
                single_instance_step: bool) -> Self {
-        let indirect_instances_layout = Self::create_indirect_layout(global_context, false);
+        let indirect_render_instances_layout = Self::create_indirect_layout(global_context, false);
         let indirect_compute_instances_layout = Self::create_indirect_layout(global_context, true);
-        let indirect_instances_args_layout = global_context.device().create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+        let indirect_compute_instances_args_layout = global_context.device().create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
             entries: &[wgpu::BindGroupLayoutEntry {
                 binding: 0,
                 visibility: ShaderStages::COMPUTE,
@@ -53,7 +59,7 @@ impl ShapePipeline {
             label: Some("Shape Compute Pipeline Layout"),
             bind_group_layouts: &[Some(&mesh_pipeline.bind_group_layout),
                 Some(&indirect_compute_instances_layout),
-                Some(&indirect_instances_args_layout)],
+                Some(&indirect_compute_instances_args_layout)],
             ..Default::default()
         });
 
@@ -61,7 +67,7 @@ impl ShapePipeline {
             label: Some("Shape Compute Reset Pipeline Layout"),
             bind_group_layouts: &[None,
                 Some(&indirect_compute_instances_layout),
-                Some(&indirect_instances_args_layout)],
+                Some(&indirect_compute_instances_args_layout)],
             ..Default::default()
         });
 
@@ -86,9 +92,10 @@ impl ShapePipeline {
         Self {
             mesh_pipeline,
             vs_func_name,
-            indirect_instances_layout,
+            bind_group_cache: BindGroupCache::new(global_context.device()),
+            indirect_render_instances_layout,
             indirect_compute_instances_layout,
-            indirect_instances_args_layout,
+            indirect_compute_instances_args_layout,
             culling_compute_pipeline,
             reset_culling_compute_pipeline,
             indirect,
@@ -132,13 +139,12 @@ impl ShapePipeline {
         })
     }
 
-    fn create_instance_bind_group(&self, global_context: &GlobalContext,
+    fn create_instance_bind_group(device: &Device,
                                   bind_group_layout: &BindGroupLayout,
                                   instance_buffer: &Buffer,
                                   culled_buffer: &Buffer,
                                   label: &'static str) -> BindGroup {
-        global_context
-            .device()
+        device
             .create_bind_group(&wgpu::BindGroupDescriptor {
                 layout: bind_group_layout,
                 entries: &[wgpu::BindGroupEntry {
@@ -161,31 +167,40 @@ impl RenderPipeline for ShapePipeline {
     fn compute_mesh(&mut self,
                     compute_pass: &mut ComputePass,
                     mesh_buffers: &MeshBuffers,
-                    global_context: &GlobalContext) {
+                    global_context: &mut GlobalContext) {
         if self.indirect {
-            if let Some(instance_args_buffer) = mesh_buffers.args_buffer() &&
-                let Some(culled_buffer) = mesh_buffers.culled_buffer() &&
-                let Some(instance_buffer) = mesh_buffers.instance_buffer() {
+            if let Some(instance_args_buffer) = mesh_buffers.args_buffer_with_id() &&
+                let Some(culled_buffer) = mesh_buffers.culled_buffer_with_id() &&
+                let Some(instance_buffer) = mesh_buffers.instance_buffer_with_id() {
+                {
+                    let instance_bind_group = self.bind_group_cache.get_bind_group_or_create(
+                        BindGroupKey::new(Self::COMPUTE_LAYOUT_ID, &[instance_buffer.id(), culled_buffer.id()]), |device| {
+                            Self::create_instance_bind_group(device,
+                                                            &self.indirect_compute_instances_layout,
+                                                            instance_buffer.buffer(),
+                                                            culled_buffer.buffer(), "Indirect compute BindGroup")
+                        });
+                    compute_pass.set_bind_group(1, instance_bind_group, &[]);
+                }
 
-                // TODO Cache BindGroups to prevent creating every time
-                let instances_args_bind_group = Some(
-                    global_context
-                        .device()
-                        .create_bind_group(&wgpu::BindGroupDescriptor {
-                            layout: &self.indirect_instances_args_layout,
-                            entries: &[wgpu::BindGroupEntry {
-                                binding: 0,
-                                resource: instance_args_buffer.as_entire_binding(),
-                            }],
-                            label: Some("instances_bind_args_group"),
-                        }),
-                );
-                let instance_bind_group = self.create_instance_bind_group(global_context, &self.indirect_compute_instances_layout,
-                                                                          &instance_buffer,
-                                                                          &culled_buffer, "Indirect compute BindGroup");
+                {
+                    let instances_args_bind_group = self.bind_group_cache.get_bind_group_or_create(
+                        BindGroupKey::new(Self::COMPUTE_LAYOUT_ID, &[instance_args_buffer.id()]),
+                        |device| {
+                            device
+                                .create_bind_group(&wgpu::BindGroupDescriptor {
+                                    layout: &self.indirect_compute_instances_args_layout,
+                                    entries: &[wgpu::BindGroupEntry {
+                                        binding: 0,
+                                        resource: instance_args_buffer.buffer().as_entire_binding(),
+                                    }],
+                                    label: Some("instances_bind_args_group"),
+                                })
+                        },
+                    );
+                    compute_pass.set_bind_group(2, instances_args_bind_group, &[]);
+                }
 
-                compute_pass.set_bind_group(1, &instance_bind_group, &[]);
-                compute_pass.set_bind_group(2, &instances_args_bind_group, &[]);
                 compute_pass.set_pipeline(&self.reset_culling_compute_pipeline);
                 compute_pass.dispatch_workgroups(1, 1, 1);
 
@@ -202,15 +217,17 @@ impl RenderPipeline for ShapePipeline {
         }
     }
 
-    fn render_mesh(&mut self, render_pass: &mut RenderPass, mesh_buffers: &MeshBuffers, global_context: &GlobalContext) {
-        if self.indirect && let Some(instance_buffer) = mesh_buffers.instance_buffer()
-            && let Some(culled_buffer) = mesh_buffers.culled_buffer() {
-            // TODO Cache BindGroup to prevent creating every time
-            let instance_bind_group = self.
-                create_instance_bind_group(global_context, &self.indirect_instances_layout,
-                                           instance_buffer,
-                                           culled_buffer, "Indirect render BindGroup");
-            render_pass.set_bind_group(2, &instance_bind_group, &[]);
+    fn render_mesh(&mut self, render_pass: &mut RenderPass, mesh_buffers: &MeshBuffers, global_context: &mut GlobalContext) {
+        if self.indirect && let Some(instance_buffer) = mesh_buffers.instance_buffer_with_id()
+            && let Some(culled_buffer) = mesh_buffers.culled_buffer_with_id() {
+            let instance_bind_group = self.bind_group_cache.get_bind_group_or_create(
+                BindGroupKey::new(Self::RENDER_LAYOUT_ID, &[instance_buffer.id(), culled_buffer.id()]), |device| {
+                    Self::create_instance_bind_group(device,
+                                                    &self.indirect_render_instances_layout,
+                                                    instance_buffer.buffer(),
+                                                    culled_buffer.buffer(), "Indirect render BindGroup")
+                });
+            render_pass.set_bind_group(2, instance_bind_group, &[]);
         } else if let Some(buffer) = mesh_buffers.instance_buffer() {
             if buffer.size() > 0 {
                 render_pass.set_vertex_buffer(1, buffer.slice(..));
@@ -227,7 +244,7 @@ impl RenderPipeline for ShapePipeline {
             Some(&global_context.styles_bind_group_layout),
         ];
         if self.indirect {
-            layouts.push(Some(&self.indirect_instances_layout))
+            layouts.push(Some(&self.indirect_render_instances_layout))
         }
         let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: Some("Shape Render Pipeline Layout"),

--- a/renderer-gpu/src/pipelines/shape_pipeline.rs
+++ b/renderer-gpu/src/pipelines/shape_pipeline.rs
@@ -163,9 +163,9 @@ impl RenderPipeline for ShapePipeline {
                     mesh_buffers: &MeshBuffers,
                     global_context: &GlobalContext) {
         if self.indirect {
-            if let Some(instance_args_buffer) = mesh_buffers.instance_args_buffer.as_ref() &&
-                let Some(culled_buffer) = mesh_buffers.culled_buffer.as_ref() &&
-                let Some(instance_buffer) = mesh_buffers.instance_buffer.as_ref() {
+            if let Some(instance_args_buffer) = mesh_buffers.args_buffer() &&
+                let Some(culled_buffer) = mesh_buffers.culled_buffer() &&
+                let Some(instance_buffer) = mesh_buffers.instance_buffer() {
 
                 // TODO Cache BindGroups to prevent creating every time
                 let instances_args_bind_group = Some(
@@ -203,15 +203,15 @@ impl RenderPipeline for ShapePipeline {
     }
 
     fn render_mesh(&mut self, render_pass: &mut RenderPass, mesh_buffers: &MeshBuffers, global_context: &GlobalContext) {
-        if self.indirect && let Some(instance_buffer) = mesh_buffers.instance_buffer.as_ref()
-            && let Some(culled_buffer) = mesh_buffers.culled_buffer.as_ref() {
+        if self.indirect && let Some(instance_buffer) = mesh_buffers.instance_buffer()
+            && let Some(culled_buffer) = mesh_buffers.culled_buffer() {
             // TODO Cache BindGroup to prevent creating every time
             let instance_bind_group = self.
                 create_instance_bind_group(global_context, &self.indirect_instances_layout,
                                            instance_buffer,
                                            culled_buffer, "Indirect render BindGroup");
             render_pass.set_bind_group(2, &instance_bind_group, &[]);
-        } else if let Some(buffer) = mesh_buffers.instance_buffer.as_ref() {
+        } else if let Some(buffer) = mesh_buffers.instance_buffer() {
             if buffer.size() > 0 {
                 render_pass.set_vertex_buffer(1, buffer.slice(..));
             } else {


### PR DESCRIPTION
## Summary
1. Added a BindGroup cache. It's currently used by ShapePipeline only, not globally.
2. Builder for MeshBuffers.
3. Minor improvements for handling of zero length buffers.