### PR TITLE
TechDebt. Divide shaders into more submodules

### DIFF
--- a/renderer-gpu/build.rs
+++ b/renderer-gpu/build.rs
@@ -5,7 +5,9 @@ fn main() {
     wesl.set_feature("CASTANO", Feature::Enable);
     wesl.set_feature("OUTLINE_DEBUG", Feature::Disable);
     wesl.build_artifact(&"package::shape_shader".parse().unwrap(), "shape_shader");
+    wesl.build_artifact(&"package::g_buf_frag_shader".parse().unwrap(), "g_buf_frag_shader");
     wesl.build_artifact(&"package::mesh_shader".parse().unwrap(), "mesh_shader");
+    wesl.build_artifact(&"package::shadow_map".parse().unwrap(), "shadow_map");
     wesl.build_artifact(&"package::screen_mesh_shader".parse().unwrap(), "screen_mesh_shader");
     wesl.build_artifact(&"package::shape_culling".parse().unwrap(), "shape_culling");
     wesl.build_artifact(&"package::ssao".parse().unwrap(), "ssao");

--- a/renderer-gpu/src/mesh_layers/general_mesh_layer.rs
+++ b/renderer-gpu/src/mesh_layers/general_mesh_layer.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use crate::draw_commands::mesh2d_draw_command::Mesh2dCommandBatch;
 use crate::global_context::{GlobalContext, GlobalRenderStep};
 use crate::mesh::mesh::Mesh;
@@ -5,11 +6,14 @@ use crate::mesh::positioned_mesh::PositionedMesh;
 use crate::mesh_layers::render_data_holder::RenderDataHolder;
 use crate::mesh_layers::BaseMeshLayer;
 use renderer_common::render_modifier::SpatialData;
-use crate::pipelines::RenderPipeline;
+use crate::pipelines::{OwnedVertexState, RenderPipeline};
 use std::mem;
+use wesl::include_wesl;
 use wgpu::TextureFormat::Rgba16Float;
-use wgpu::{CommandEncoder, ComputePassDescriptor, Face, RenderPass, TextureFormat};
+use wgpu::{CommandEncoder, ComputePassDescriptor, Face, RenderPass, ShaderModuleDescriptor, ShaderSource, TextureFormat};
+use renderer_common::geometry_data::MeshVertex;
 use crate::buffer_pool::BufferPool;
+use crate::vertex_attrs::{GeneralInstanceInput, VertexAttrib};
 
 pub(crate) struct GeneralMeshLayer<P: RenderPipeline> {
     render_pipeline: P,
@@ -103,8 +107,14 @@ impl<P: RenderPipeline> BaseMeshLayer for GeneralMeshLayer<P> {
         self.pipeline = Some(descriptor.to_render_pipeline(global_context.device()));
 
         if self.render_pipeline.support_g_buf() {
+            let g_buf_frag_shader_module = global_context.device().create_shader_module(ShaderModuleDescriptor {
+                label: Some("g_buf_frag_shader"),
+                source: ShaderSource::Wgsl(Cow::from(include_wesl!("g_buf_frag_shader"))),
+            });
+
             g_buffer_descriptor.label = Some("g_buffer_pipeline");
             let fragment = g_buffer_descriptor.fragment.as_mut().unwrap();
+            fragment.module = g_buf_frag_shader_module;
             fragment.targets = vec![Some(wgpu::ColorTargetState {
                 format: Rgba16Float,
                 blend: None,
@@ -121,7 +131,17 @@ impl<P: RenderPipeline> BaseMeshLayer for GeneralMeshLayer<P> {
             self.g_buffer_pipeline = Some(g_buffer_descriptor.to_render_pipeline(global_context.device()));
         }
 
+        let shadow_map_shader_module = global_context.device().create_shader_module(ShaderModuleDescriptor {
+            label: Some("shadow_map"),
+            source: ShaderSource::Wgsl(Cow::from(include_wesl!("shadow_map"))),
+        });
         shadow_descriptor.label = Some("shadow_pipeline");
+        shadow_descriptor.vertex = OwnedVertexState {
+            module: shadow_map_shader_module,
+            entry_point: Some("vs_main"),
+            compilation_options: Default::default(),
+            buffers: vec![MeshVertex::desc(), GeneralInstanceInput::desc()],
+        };
         shadow_descriptor.fragment = None;
         shadow_descriptor.primitive.cull_mode = Some(Face::Front);
         shadow_descriptor.multisample.count = 1;

--- a/renderer-gpu/src/shaders/g_buf_frag_shader.wgsl
+++ b/renderer-gpu/src/shaders/g_buf_frag_shader.wgsl
@@ -1,0 +1,12 @@
+import super::mesh_shader_common::{VertexOutput};
+
+struct GBuffer {
+    @location(0) positions: vec4<f32>,
+    @location(1) normal: vec4<f32>,
+}
+
+@fragment
+fn fs_main_g_buf(in: VertexOutput) -> GBuffer {
+    // TODO use view matrix to calc z in VS instead of in.clip_position.z?
+    return GBuffer(vec4(in.view_position.xyz, 1.0), vec4(in.view_normal.xyz, 1.0));
+}

--- a/renderer-gpu/src/shaders/mesh_shader.wgsl
+++ b/renderer-gpu/src/shaders/mesh_shader.wgsl
@@ -1,42 +1,11 @@
+import super::mesh_shader_common::{VertexInput, InstanceInput, VertexOutput};
 import super::common::CameraUniform;
 import super::common::shadow_map;
-
-// Vertex shader
 
 @group(0) @binding(0)
 var<uniform> camera: CameraUniform;
 
 var<immediate> params: u32;
-
-struct VertexInput {
-    @location(0) position: vec3<f32>,
-    @location(1) normal: vec3<f32>,
-}
-
-struct InstanceInput {
-    @location(4) position: vec3<f32>,
-    @location(5) color_alpha: f32,
-    @location(6) model_matrix_0: vec4<f32>,
-    @location(7) model_matrix_1: vec4<f32>,
-    @location(8) model_matrix_2: vec4<f32>,
-    @location(9) model_matrix_3: vec4<f32>,
-}
-
-struct VertexOutput {
-    @builtin(position) clip_position: vec4<f32>,
-    @location(1) view_normal: vec3<f32>,
-    @location(2) view_position: vec3<f32>,
-    @location(3) world_normal: vec3<f32>,
-    @location(4) world_position: vec3<f32>,
-    @location(5) pos_from_light: vec4<f32>,
-    @location(6) color_alpha: f32,
-    @location(7) height: f32,
-}
-
-struct GBuffer {
-    @location(0) positions: vec4<f32>,
-    @location(1) normal: vec4<f32>,
-}
 
 @vertex
 fn vs_main(
@@ -55,27 +24,24 @@ fn vs_main(
     var out: VertexOutput;
     var modelpos = model_position.xyz + pos.position;
 
-    if((params & 1) > 0) {
-        out.clip_position = camera.light_view_proj * vec4<f32>(modelpos, 1.0);
-    } else {
-        var modelnormal = model.normal;
-        // TODO
-        modelnormal.z = -abs(modelnormal.z);
-        out.world_position = modelpos;
-        out.world_normal = -modelnormal;
+    var modelnormal = model.normal;
+    // TODO
+    modelnormal.z = -abs(modelnormal.z);
+    out.world_position = modelpos;
+    out.world_normal = -modelnormal;
 
-        out.view_position = (camera.view * vec4f(modelpos, 1.0)).xyz;
-        out.view_normal = (camera.view_tr_inv * vec4f(modelnormal, 1.0)).xyz;
-        out.color_alpha = pos.color_alpha;
+    out.view_position = (camera.view * vec4f(modelpos, 1.0)).xyz;
+    out.view_normal = (camera.view_tr_inv * vec4f(modelnormal, 1.0)).xyz;
+    out.color_alpha = pos.color_alpha;
 
-        // check scale_2d_3d, when geometry is flat height = 1.0 gives a correct value for gradient in fragment shader
-        if(modelpos.z > 0.0 || camera.scale_2d_3d == 0.0) {
-            // technically, normalized z coord
-            out.height = 1.0;
-        }
-        out.pos_from_light = camera.light_view_proj * vec4<f32>(modelpos, 1.0);
-        out.clip_position = camera.view_proj * vec4<f32>(modelpos, 1.0);
+    // check scale_2d_3d, when geometry is flat height = 1.0 gives a correct value for gradient in fragment shader
+    if(modelpos.z > 0.0 || camera.scale_2d_3d == 0.0) {
+        // technically, normalized z coord
+        out.height = 1.0;
     }
+    out.pos_from_light = camera.light_view_proj * vec4<f32>(modelpos, 1.0);
+    out.clip_position = camera.view_proj * vec4<f32>(modelpos, 1.0);
+
     return out;
 }
 
@@ -124,11 +90,4 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32>  {
     let final_color = (result_color) + (noise - 0.5) * dither_strength;
 
     return vec4(final_color, in.color_alpha);
-}
-
-@fragment
-fn fs_main_g_buf(in: VertexOutput) -> GBuffer {
-
-    // TODO use view matrix to calc z in VS instead of in.clip_position.z?
-    return GBuffer(vec4(in.view_position.xyz, 1.0), vec4(in.view_normal.xyz, 1.0));
 }

--- a/renderer-gpu/src/shaders/mesh_shader_common.wgsl
+++ b/renderer-gpu/src/shaders/mesh_shader_common.wgsl
@@ -1,0 +1,26 @@
+import super::common::CameraUniform;
+
+struct VertexInput {
+    @location(0) position: vec3<f32>,
+    @location(1) normal: vec3<f32>,
+}
+
+struct InstanceInput {
+    @location(4) position: vec3<f32>,
+    @location(5) color_alpha: f32,
+    @location(6) model_matrix_0: vec4<f32>,
+    @location(7) model_matrix_1: vec4<f32>,
+    @location(8) model_matrix_2: vec4<f32>,
+    @location(9) model_matrix_3: vec4<f32>,
+}
+
+struct VertexOutput {
+    @builtin(position) clip_position: vec4<f32>,
+    @location(1) view_normal: vec3<f32>,
+    @location(2) view_position: vec3<f32>,
+    @location(3) world_normal: vec3<f32>,
+    @location(4) world_position: vec3<f32>,
+    @location(5) pos_from_light: vec4<f32>,
+    @location(6) color_alpha: f32,
+    @location(7) height: f32,
+}

--- a/renderer-gpu/src/shaders/shadow_map.wgsl
+++ b/renderer-gpu/src/shaders/shadow_map.wgsl
@@ -1,0 +1,26 @@
+import super::mesh_shader_common::{VertexInput, InstanceInput, VertexOutput};
+import super::common::CameraUniform;
+
+@group(0) @binding(0)
+var<uniform> camera: CameraUniform;
+
+@vertex
+fn vs_main(
+    model: VertexInput,
+    pos: InstanceInput
+) -> VertexOutput {
+    let model_matrix = mat4x4<f32>(
+            pos.model_matrix_0,
+            pos.model_matrix_1,
+            pos.model_matrix_2,
+            pos.model_matrix_3,
+    );
+    var model_position = model_matrix * vec4(model.position.xyz, 1.0);
+    model_position.z = model_position.z * camera.scale_2d_3d;
+
+    var out: VertexOutput;
+    var modelpos = model_position.xyz + pos.position;
+
+    out.clip_position = camera.light_view_proj * vec4<f32>(modelpos, 1.0);
+    return out;
+}


### PR DESCRIPTION
## Summary
Moved some part of `mesh_shader` into common module and created dedicated modules for shadow map and g-buffer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added G-buffer rendering with view-space position and normal outputs.
  * Added dedicated shadow-map rendering for mesh instances.
  * Improved mesh rendering to support shared vertex data and consistent lighting, camera, and depth calculations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->