### PR TITLE
TechDebt. Refactor mesh instance types

### DIFF
--- a/renderer-gpu/src/mesh/mesh_instance_input.rs
+++ b/renderer-gpu/src/mesh/mesh_instance_input.rs
@@ -44,7 +44,7 @@ pub trait MeshInstanceInput: Sized + Pod + From<LayerAttrubute> {
     }
 }
 
-impl<T> MeshInstanceInput for T where T: Sized + Pod + From<LayerAttrubute> {}
+impl<T> MeshInstanceInput for T where T: Clone + Default + Sized + Pod + From<LayerAttrubute> {}
 
 impl From<LayerAttrubute> for GeneralInstanceInput {
     fn from(value: LayerAttrubute) -> Self {

--- a/renderer-gpu/src/mesh/mesh_instance_input.rs
+++ b/renderer-gpu/src/mesh/mesh_instance_input.rs
@@ -2,23 +2,12 @@ use crate::vertex_attrs::{GeneralInstanceInput, ScreenShapeInstanceInput, ShapeI
 use bytemuck::Pod;
 use glam::DVec3;
 use renderer_common::render_modifier::SpatialData;
+use crate::mesh_layers::{LayerAttrMapper, LayerAttrubute};
 
-#[derive(Default)]
-pub struct CommonAttributes {
-    pub(crate) position: [f32; 3],
-    pub(crate) color_alpha: f32,
-    pub(crate) matrix: [[f32; 4]; 4],
-    pub(crate) bbox: [f32; 4],
-    pub(crate) normal_scale: f32,
-    pub(crate) screen_space: u32,
-}
-
-pub type AttrMapper<I> = fn(CommonAttributes) -> I;
-
-pub trait MeshInstanceInput: Sized + Pod + From<CommonAttributes> {
+pub trait MeshInstanceInput: Sized + Pod + From<LayerAttrubute> {
     fn fill_attrs(
         attrs: &mut Vec<Self>,
-        attr_mapper: AttrMapper<Self>,
+        attr_mapper: LayerAttrMapper<Self>,
         cs_offset: &DVec3,
         original_positions_alpha: &Vec<(DVec3, f32)>,
         spatial_data: &SpatialData,
@@ -36,7 +25,7 @@ pub trait MeshInstanceInput: Sized + Pod + From<CommonAttributes> {
                 + DVec3::new(spatial_data.bbox.min().x, spatial_data.bbox.min().y, 0.0)
                 - cs_offset;
 
-            let instance_input = attr_mapper(CommonAttributes {
+            let instance_input = attr_mapper(LayerAttrubute {
                 position: transform_with_cs_offset.as_vec3().to_array(),
                 color_alpha: item.1,
                 matrix: matrix.as_mat4().to_cols_array_2d(),
@@ -55,14 +44,10 @@ pub trait MeshInstanceInput: Sized + Pod + From<CommonAttributes> {
     }
 }
 
-impl MeshInstanceInput for GeneralInstanceInput {}
+impl<T> MeshInstanceInput for T where T: Sized + Pod + From<LayerAttrubute> {}
 
-impl MeshInstanceInput for ShapeInstanceInput {}
-
-impl MeshInstanceInput for ScreenShapeInstanceInput {}
-
-impl From<CommonAttributes> for GeneralInstanceInput {
-    fn from(value: CommonAttributes) -> Self {
+impl From<LayerAttrubute> for GeneralInstanceInput {
+    fn from(value: LayerAttrubute) -> Self {
         GeneralInstanceInput {
             position: value.position,
             color_alpha: value.color_alpha,
@@ -71,8 +56,8 @@ impl From<CommonAttributes> for GeneralInstanceInput {
     }
 }
 
-impl From<CommonAttributes> for ShapeInstanceInput {
-    fn from(value: CommonAttributes) -> Self {
+impl From<LayerAttrubute> for ShapeInstanceInput {
+    fn from(value: LayerAttrubute) -> Self {
         ShapeInstanceInput {
             position: value.position,
             color_alpha: value.color_alpha,
@@ -84,8 +69,8 @@ impl From<CommonAttributes> for ShapeInstanceInput {
     }
 }
 
-impl From<CommonAttributes> for ScreenShapeInstanceInput {
-    fn from(value: CommonAttributes) -> Self {
+impl From<LayerAttrubute> for ScreenShapeInstanceInput {
+    fn from(value: LayerAttrubute) -> Self {
         ScreenShapeInstanceInput {
             position: value.position,
             color_alpha: value.color_alpha,

--- a/renderer-gpu/src/mesh/mesh_instance_input.rs
+++ b/renderer-gpu/src/mesh/mesh_instance_input.rs
@@ -2,9 +2,9 @@ use crate::vertex_attrs::{GeneralInstanceInput, ScreenShapeInstanceInput, ShapeI
 use bytemuck::Pod;
 use glam::DVec3;
 use renderer_common::render_modifier::SpatialData;
-use crate::mesh_layers::{LayerAttrMapper, LayerAttrubute};
+use crate::mesh_layers::{LayerAttrMapper, LayerAttribute};
 
-pub trait MeshInstanceInput: Sized + Pod + From<LayerAttrubute> {
+pub trait MeshInstanceInput: Sized + Pod + From<LayerAttribute> {
     fn fill_attrs(
         attrs: &mut Vec<Self>,
         attr_mapper: LayerAttrMapper<Self>,
@@ -25,7 +25,7 @@ pub trait MeshInstanceInput: Sized + Pod + From<LayerAttrubute> {
                 + DVec3::new(spatial_data.bbox.min().x, spatial_data.bbox.min().y, 0.0)
                 - cs_offset;
 
-            let instance_input = attr_mapper(LayerAttrubute {
+            let instance_input = attr_mapper(LayerAttribute {
                 position: transform_with_cs_offset.as_vec3().to_array(),
                 color_alpha: item.1,
                 matrix: matrix.as_mat4().to_cols_array_2d(),
@@ -44,10 +44,10 @@ pub trait MeshInstanceInput: Sized + Pod + From<LayerAttrubute> {
     }
 }
 
-impl<T> MeshInstanceInput for T where T: Clone + Default + Sized + Pod + From<LayerAttrubute> {}
+impl<T> MeshInstanceInput for T where T: Clone + Default + Sized + Pod + From<LayerAttribute> {}
 
-impl From<LayerAttrubute> for GeneralInstanceInput {
-    fn from(value: LayerAttrubute) -> Self {
+impl From<LayerAttribute> for GeneralInstanceInput {
+    fn from(value: LayerAttribute) -> Self {
         GeneralInstanceInput {
             position: value.position,
             color_alpha: value.color_alpha,
@@ -56,8 +56,8 @@ impl From<LayerAttrubute> for GeneralInstanceInput {
     }
 }
 
-impl From<LayerAttrubute> for ShapeInstanceInput {
-    fn from(value: LayerAttrubute) -> Self {
+impl From<LayerAttribute> for ShapeInstanceInput {
+    fn from(value: LayerAttribute) -> Self {
         ShapeInstanceInput {
             position: value.position,
             color_alpha: value.color_alpha,
@@ -69,8 +69,8 @@ impl From<LayerAttrubute> for ShapeInstanceInput {
     }
 }
 
-impl From<LayerAttrubute> for ScreenShapeInstanceInput {
-    fn from(value: LayerAttrubute) -> Self {
+impl From<LayerAttribute> for ScreenShapeInstanceInput {
+    fn from(value: LayerAttribute) -> Self {
         ScreenShapeInstanceInput {
             position: value.position,
             color_alpha: value.color_alpha,

--- a/renderer-gpu/src/mesh/mesh_instance_input.rs
+++ b/renderer-gpu/src/mesh/mesh_instance_input.rs
@@ -1,9 +1,7 @@
-use renderer_common::render_modifier::SpatialData;
-use crate::vertex_attrs::{GeneralInstanceInput, ShapeInstanceInput, ScreenShapeInstanceInput};
+use crate::vertex_attrs::{GeneralInstanceInput, ScreenShapeInstanceInput, ShapeInstanceInput};
 use bytemuck::Pod;
 use glam::DVec3;
-use crate::mesh::mesh::Mesh;
-use crate::mesh::positioned_mesh::PositionedMesh;
+use renderer_common::render_modifier::SpatialData;
 
 #[derive(Default)]
 pub struct MeshInstanceInputBuilder {
@@ -70,13 +68,6 @@ pub trait MeshInstanceInput: Sized + Pod {
             matrix,
             ..Default::default()
         }
-    }
-
-    fn create_positioned_mesh(spatial_rx: tokio::sync::broadcast::Receiver<SpatialData>,
-                              double_style: bool,
-                              instance_positions_alpha: Option<Vec<(DVec3, f32)>>,
-                              mesh: Mesh) -> PositionedMesh<Self> {
-        mesh.to_positioned::<Self>(spatial_rx, double_style, instance_positions_alpha)
     }
 
     fn fill_attrs(

--- a/renderer-gpu/src/mesh/mesh_instance_input.rs
+++ b/renderer-gpu/src/mesh/mesh_instance_input.rs
@@ -4,74 +4,21 @@ use glam::DVec3;
 use renderer_common::render_modifier::SpatialData;
 
 #[derive(Default)]
-pub struct MeshInstanceInputBuilder {
-    position: [f32; 3],
-    color_alpha: f32,
-    matrix: [[f32; 4]; 4],
-    bbox: Option<[f32; 4]>,
-    normal_scale: Option<f32>,
-    screen_space: Option<u32>,
+pub struct CommonAttributes {
+    pub(crate) position: [f32; 3],
+    pub(crate) color_alpha: f32,
+    pub(crate) matrix: [[f32; 4]; 4],
+    pub(crate) bbox: [f32; 4],
+    pub(crate) normal_scale: f32,
+    pub(crate) screen_space: u32,
 }
 
-impl MeshInstanceInputBuilder {
+pub type AttrMapper<I> = fn(CommonAttributes) -> I;
 
-    pub fn with_bbox(mut self, bbox: [f32; 4]) -> Self {
-        self.bbox = Some(bbox);
-        self
-    }
-
-    pub fn with_normal_scale(mut self, normal_scale: f32) -> Self {
-        self.normal_scale = Some(normal_scale);
-        self
-    }
-
-    pub fn with_screen_space(mut self, screen_space: u32) -> Self {
-        self.screen_space = Some(screen_space);
-        self
-    }
-
-    fn position(&self) -> [f32; 3] {
-        self.position
-    }
-
-    fn color_alpha(&self) -> f32 {
-        self.color_alpha
-    }
-
-    fn matrix(&self) -> [[f32; 4]; 4] {
-        self.matrix
-    }
-
-    fn bbox(&self) -> [f32; 4] {
-        self.bbox.expect("MeshInstanceInputBuilder expected bbox")
-    }
-
-    fn normal_scale(&self) -> f32 {
-        self.normal_scale.expect("MeshInstanceInputBuilder expected normal_scale")
-    }
-
-    fn screen_space(&self) -> u32 {
-        self.screen_space.expect("MeshInstanceInputBuilder expected screen_space")
-    }
-    pub(crate) fn build<I: MeshInstanceInput>(self) -> I {
-        I::create_instance_struct(self)
-    }
-}
-
-pub trait MeshInstanceInput: Sized + Pod {
-    fn builder(position: [f32; 3],
-               color_alpha: f32,
-               matrix: [[f32; 4]; 4]) -> MeshInstanceInputBuilder {
-        MeshInstanceInputBuilder {
-            position,
-            color_alpha,
-            matrix,
-            ..Default::default()
-        }
-    }
-
+pub trait MeshInstanceInput: Sized + Pod + From<CommonAttributes> {
     fn fill_attrs(
         attrs: &mut Vec<Self>,
+        attr_mapper: AttrMapper<Self>,
         cs_offset: &DVec3,
         original_positions_alpha: &Vec<(DVec3, f32)>,
         spatial_data: &SpatialData,
@@ -85,57 +32,65 @@ pub trait MeshInstanceInput: Sized + Pod {
             }
 
             let transform_with_cs_offset = item.0 + spatial_data.transform - cs_offset;
-
             let bbox_origin_with_cs_offset = item.0
-                + DVec3::new(spatial_data.bbox.min().x, spatial_data.bbox.min().y, 0.0) - cs_offset;
-            let instance_input = Self::builder(transform_with_cs_offset.as_vec3().to_array(),
-                                               item.1,
-                                               matrix.as_mat4().to_cols_array_2d(),
-            ).with_bbox([
-                bbox_origin_with_cs_offset.x as f32,
-                bbox_origin_with_cs_offset.y as f32,
-                spatial_data.bbox.width() as f32,
-                spatial_data.bbox.height() as f32,
-            ])
-                .with_normal_scale(spatial_data.normal_scale as f32).build();
+                + DVec3::new(spatial_data.bbox.min().x, spatial_data.bbox.min().y, 0.0)
+                - cs_offset;
+
+            let instance_input = attr_mapper(CommonAttributes {
+                position: transform_with_cs_offset.as_vec3().to_array(),
+                color_alpha: item.1,
+                matrix: matrix.as_mat4().to_cols_array_2d(),
+                bbox: [
+                    bbox_origin_with_cs_offset.x as f32,
+                    bbox_origin_with_cs_offset.y as f32,
+                    spatial_data.bbox.width() as f32,
+                    spatial_data.bbox.height() as f32,
+                ],
+                normal_scale: spatial_data.normal_scale as f32,
+                ..Default::default()
+            });
+
             attrs.push(instance_input);
         }
     }
-
-    fn create_instance_struct(builder: MeshInstanceInputBuilder) -> Self;
 }
 
-impl MeshInstanceInput for GeneralInstanceInput {
-    fn create_instance_struct(builder: MeshInstanceInputBuilder) -> Self {
-        Self {
-            position: builder.position(),
-            color_alpha: builder.color_alpha(),
-            matrix: builder.matrix(),
+impl MeshInstanceInput for GeneralInstanceInput {}
+
+impl MeshInstanceInput for ShapeInstanceInput {}
+
+impl MeshInstanceInput for ScreenShapeInstanceInput {}
+
+impl From<CommonAttributes> for GeneralInstanceInput {
+    fn from(value: CommonAttributes) -> Self {
+        GeneralInstanceInput {
+            position: value.position,
+            color_alpha: value.color_alpha,
+            matrix: value.matrix,
         }
     }
 }
 
-impl MeshInstanceInput for ShapeInstanceInput {
-
-    fn create_instance_struct(builder: MeshInstanceInputBuilder) -> Self {
-        Self {
-            position: builder.position(),
-            color_alpha: builder.color_alpha(),
-            matrix: builder.matrix(),
-            bbox: builder.bbox(),
-            normal_scale: builder.normal_scale(),
+impl From<CommonAttributes> for ShapeInstanceInput {
+    fn from(value: CommonAttributes) -> Self {
+        ShapeInstanceInput {
+            position: value.position,
+            color_alpha: value.color_alpha,
+            matrix: value.matrix,
+            bbox: value.bbox,
+            normal_scale: value.normal_scale,
             _padding: [0; 3],
         }
     }
 }
 
-impl MeshInstanceInput for ScreenShapeInstanceInput {
-    fn create_instance_struct(builder: MeshInstanceInputBuilder) -> Self {
-        Self {
-            position: builder.position(),
-            color_alpha: builder.color_alpha(),
-            matrix: builder.matrix(),
-            screen_space: builder.screen_space(),
+impl From<CommonAttributes> for ScreenShapeInstanceInput {
+    fn from(value: CommonAttributes) -> Self {
+        ScreenShapeInstanceInput {
+            position: value.position,
+            color_alpha: value.color_alpha,
+            matrix: value.matrix,
+            screen_space: value.screen_space,
         }
     }
 }

--- a/renderer-gpu/src/mesh/positioned_mesh.rs
+++ b/renderer-gpu/src/mesh/positioned_mesh.rs
@@ -1,7 +1,7 @@
 use crate::global_context::GlobalContext;
 use crate::mesh::InstanceBuffer;
 use crate::mesh::mesh::Mesh;
-use crate::mesh::mesh_instance_input::{AttrMapper, CommonAttributes, MeshInstanceInput};
+use crate::mesh::mesh_instance_input::{MeshInstanceInput};
 use crate::mesh_buffers::MeshBuffers;
 use crate::utils::ReceiverExt;
 use glam::DVec3;
@@ -9,10 +9,11 @@ use renderer_common::render_modifier::SpatialData;
 use tokio::sync::broadcast::Receiver;
 use wgpu::util::{DeviceExt, DrawIndexedIndirectArgs};
 use wgpu::{ComputePass, RenderPass};
+use crate::mesh_layers::LayerAttrMapper;
 
 pub struct PositionedMesh<T: MeshInstanceInput> {
     mesh: Mesh,
-    attr_map: AttrMapper<T>,
+    attr_map: LayerAttrMapper<T>,
     instance_buffer: InstanceBuffer<T>,
     attrs: Vec<T>,
     cs_offset: DVec3,
@@ -26,7 +27,7 @@ pub struct PositionedMesh<T: MeshInstanceInput> {
 impl Mesh {
     pub(crate) fn to_positioned<T: MeshInstanceInput>(
         self,
-        attr_map: AttrMapper<T>,
+        attr_map: LayerAttrMapper<T>,
         spatial_rx: tokio::sync::broadcast::Receiver<SpatialData>,
         double_style: bool,
         instance_positions_alpha: Option<Vec<(DVec3, f32)>>,
@@ -38,7 +39,7 @@ impl Mesh {
 impl<T: MeshInstanceInput> PositionedMesh<T> {
     pub fn new(
         mesh: Mesh,
-        attr_map: AttrMapper<T>,
+        attr_map: LayerAttrMapper<T>,
         spatial_rx: tokio::sync::broadcast::Receiver<SpatialData>,
         double_style: bool,
         instance_positions_alpha: Option<Vec<(DVec3, f32)>>,

--- a/renderer-gpu/src/mesh/positioned_mesh.rs
+++ b/renderer-gpu/src/mesh/positioned_mesh.rs
@@ -23,7 +23,7 @@ pub struct PositionedMesh<T: MeshInstanceInput> {
 }
 
 impl Mesh {
-    pub fn to_positioned<T: MeshInstanceInput>(
+    pub(crate) fn to_positioned<T: MeshInstanceInput>(
         self,
         spatial_rx: tokio::sync::broadcast::Receiver<SpatialData>,
         double_style: bool,

--- a/renderer-gpu/src/mesh/positioned_mesh.rs
+++ b/renderer-gpu/src/mesh/positioned_mesh.rs
@@ -21,7 +21,7 @@ pub struct PositionedMesh<T: MeshInstanceInput> {
     spatial_rx: Receiver<SpatialData>,
     original_spatial_data: SpatialData,
     original_instance_positions_alpha: Vec<(DVec3, f32)>,
-    mesh_buffers: MeshBuffers
+    mesh_buffers: MeshBuffers<T>
 }
 
 impl Mesh {
@@ -119,15 +119,13 @@ impl<T: MeshInstanceInput> PositionedMesh<T> {
                     usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::INDIRECT |wgpu::BufferUsages::COPY_DST,
                 });
 
-                if let Some(instance_buffer) = self.instance_buffer.buffer.as_ref() {
-                    self.mesh_buffers = MeshBuffers::builder()
-                        .with_instance_buffer(Some(instance_buffer.clone()))
-                        .with_culled_and_args_buffer(Some(culled_buffer), Some(indirect_args))
-                }
+                self.mesh_buffers = MeshBuffers::builder()
+                    .with_instance_buffer(&self.instance_buffer)
+                    .with_culled_and_args_buffer(Some(culled_buffer), Some(indirect_args))
 
             } else {
                 self.mesh_buffers = MeshBuffers::builder()
-                    .with_instance_buffer(self.instance_buffer.buffer.clone())
+                    .with_instance_buffer(&self.instance_buffer)
             }
         }
     }
@@ -152,7 +150,7 @@ impl<T: MeshInstanceInput> PositionedMesh<T> {
         self.instance_buffer.length * factor
     }
 
-    pub fn get_mesh_buffers(&self) -> &MeshBuffers {
+    pub fn get_mesh_buffers(&self) -> &MeshBuffers<T> {
         &self.mesh_buffers
     }
 

--- a/renderer-gpu/src/mesh/positioned_mesh.rs
+++ b/renderer-gpu/src/mesh/positioned_mesh.rs
@@ -1,7 +1,7 @@
 use crate::global_context::GlobalContext;
 use crate::mesh::InstanceBuffer;
 use crate::mesh::mesh::Mesh;
-use crate::mesh::mesh_instance_input::MeshInstanceInput;
+use crate::mesh::mesh_instance_input::{AttrMapper, CommonAttributes, MeshInstanceInput};
 use crate::mesh_buffers::MeshBuffers;
 use crate::utils::ReceiverExt;
 use glam::DVec3;
@@ -12,6 +12,7 @@ use wgpu::{ComputePass, RenderPass};
 
 pub struct PositionedMesh<T: MeshInstanceInput> {
     mesh: Mesh,
+    attr_map: AttrMapper<T>,
     instance_buffer: InstanceBuffer<T>,
     attrs: Vec<T>,
     cs_offset: DVec3,
@@ -25,23 +26,26 @@ pub struct PositionedMesh<T: MeshInstanceInput> {
 impl Mesh {
     pub(crate) fn to_positioned<T: MeshInstanceInput>(
         self,
+        attr_map: AttrMapper<T>,
         spatial_rx: tokio::sync::broadcast::Receiver<SpatialData>,
         double_style: bool,
         instance_positions_alpha: Option<Vec<(DVec3, f32)>>,
     ) -> PositionedMesh<T> {
-        PositionedMesh::new(self, spatial_rx, double_style, instance_positions_alpha)
+        PositionedMesh::new(self, attr_map, spatial_rx, double_style, instance_positions_alpha)
     }
 }
 
 impl<T: MeshInstanceInput> PositionedMesh<T> {
     pub fn new(
         mesh: Mesh,
+        attr_map: AttrMapper<T>,
         spatial_rx: tokio::sync::broadcast::Receiver<SpatialData>,
         double_style: bool,
         instance_positions_alpha: Option<Vec<(DVec3, f32)>>,
     ) -> Self {
         Self {
             mesh,
+            attr_map,
             instance_buffer: InstanceBuffer::default(),
             attrs: vec![],
             cs_offset: DVec3::new(0.0, 0.0, 0.0),
@@ -71,6 +75,7 @@ impl<T: MeshInstanceInput> PositionedMesh<T> {
         if update_attrs {
             T::fill_attrs(
                 &mut self.attrs,
+                self.attr_map,
                 &self.cs_offset,
                 &self.original_instance_positions_alpha,
                 &self.original_spatial_data,

--- a/renderer-gpu/src/mesh_buffers.rs
+++ b/renderer-gpu/src/mesh_buffers.rs
@@ -1,20 +1,45 @@
+use std::marker::PhantomData;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use wgpu::Buffer;
+use crate::mesh::InstanceBuffer;
+use crate::mesh::mesh_instance_input::MeshInstanceInput;
 
-#[derive(Clone, Default)]
-pub struct MeshBuffers {
+pub struct MeshBuffers<I: MeshInstanceInput> {
     instance_buffer: Option<BufferWithId>,
     culled_buffer: Option<BufferWithId>,
     instance_args_buffer: Option<BufferWithId>,
+    _phantom_data: PhantomData<I>,
 }
 
-impl MeshBuffers {
-    pub fn builder() -> MeshBuffers {
+impl<I: MeshInstanceInput> Clone for MeshBuffers<I> {
+    fn clone(&self) -> Self {
+        MeshBuffers::<I> {
+            instance_buffer: self.instance_buffer.clone(),
+            culled_buffer: self.culled_buffer.clone(),
+            instance_args_buffer: self.instance_args_buffer.clone(),
+            _phantom_data: PhantomData,
+        }
+    }
+}
+
+impl<I: MeshInstanceInput> Default for MeshBuffers<I> {
+    fn default() -> Self {
+        MeshBuffers::<I> {
+            instance_buffer: None,
+            culled_buffer: None,
+            instance_args_buffer: None,
+            _phantom_data: PhantomData,
+        }
+    }
+}
+
+impl<I: MeshInstanceInput> MeshBuffers<I> {
+    pub fn builder() -> MeshBuffers<I> {
         Self::default()
     }
 
-    pub fn with_instance_buffer(mut self, buffer: Option<Buffer>) -> Self {
-        self.instance_buffer = buffer.map(Into::into);
+    pub fn with_instance_buffer(mut self, instance_buffer: &InstanceBuffer<I>) -> Self {
+        self.instance_buffer = instance_buffer.buffer.clone().map(Into::into);
         self
     }
 

--- a/renderer-gpu/src/mesh_layers/general_mesh_layer.rs
+++ b/renderer-gpu/src/mesh_layers/general_mesh_layer.rs
@@ -32,13 +32,9 @@ impl<I: MeshInstanceInput> GeneralMeshLayer<I> {
         double_style: bool,
         mesh: Mesh,
     ) {
-
-        let mesh = I::create_positioned_mesh(
-            spatial_rx,
-            double_style,
-            None,
-            mesh,
-        );
+        let mesh = mesh.to_positioned(spatial_rx,
+                                      double_style,
+                                      None);
         self.render_data_holder.set(key, vec![mesh]);
     }
 
@@ -62,13 +58,10 @@ impl<I: MeshInstanceInput> GeneralMeshLayer<I> {
             mem::take(&mut batch.mesh_info.instance_positions).map(|pos_items| pos_items.into_iter().map(|item| {
                 (item, 1f32)
             }).collect());
-
-        let mesh = I::create_positioned_mesh(
-            spatial_rx,
-            batch.mesh_info.double_style,
-            instance_positions,
-            mesh,
-        );
+        
+        let mesh = mesh.to_positioned(spatial_rx,
+                                      batch.mesh_info.double_style,
+                                      instance_positions);
         self.render_data_holder.set(key.to_string(), vec![mesh]);
     }
 }

--- a/renderer-gpu/src/mesh_layers/general_mesh_layer.rs
+++ b/renderer-gpu/src/mesh_layers/general_mesh_layer.rs
@@ -9,20 +9,22 @@ use crate::pipelines::RenderPipeline;
 use renderer_common::render_modifier::SpatialData;
 use std::mem;
 use wgpu::{CommandEncoder, ComputePassDescriptor, RenderPass};
-use crate::mesh::mesh_instance_input::MeshInstanceInput;
+use crate::mesh::mesh_instance_input::{AttrMapper, MeshInstanceInput};
 
 pub(crate) struct GeneralMeshLayer<I: MeshInstanceInput> {
     render_data_holder: RenderDataHolder<PositionedMesh<I>>,
     indirect: bool,
     pub disable_skip_mesh_feature: bool,
+    attr_map: AttrMapper<I>
 }
 
 impl<I: MeshInstanceInput> GeneralMeshLayer<I> {
-    pub fn new(indirect: bool) -> Self {
+    pub fn new(indirect: bool, attr_map: AttrMapper<I>) -> Self {
         GeneralMeshLayer {
             render_data_holder: RenderDataHolder::new(),
             indirect,
             disable_skip_mesh_feature: false,
+            attr_map
         }
     }
     pub fn add(
@@ -32,7 +34,7 @@ impl<I: MeshInstanceInput> GeneralMeshLayer<I> {
         double_style: bool,
         mesh: Mesh,
     ) {
-        let mesh = mesh.to_positioned(spatial_rx,
+        let mesh = mesh.to_positioned(self.attr_map, spatial_rx,
                                       double_style,
                                       None);
         self.render_data_holder.set(key, vec![mesh]);
@@ -58,8 +60,9 @@ impl<I: MeshInstanceInput> GeneralMeshLayer<I> {
             mem::take(&mut batch.mesh_info.instance_positions).map(|pos_items| pos_items.into_iter().map(|item| {
                 (item, 1f32)
             }).collect());
-        
-        let mesh = mesh.to_positioned(spatial_rx,
+
+        let mesh = mesh.to_positioned(self.attr_map,
+                                      spatial_rx,
                                       batch.mesh_info.double_style,
                                       instance_positions);
         self.render_data_holder.set(key.to_string(), vec![mesh]);

--- a/renderer-gpu/src/mesh_layers/general_mesh_layer.rs
+++ b/renderer-gpu/src/mesh_layers/general_mesh_layer.rs
@@ -4,22 +4,22 @@ use crate::global_context::GlobalContext;
 use crate::mesh::mesh::Mesh;
 use crate::mesh::positioned_mesh::PositionedMesh;
 use crate::mesh_layers::render_data_holder::RenderDataHolder;
-use crate::mesh_layers::{BaseMeshComputeLayerNew, BaseMeshLayer, BaseMeshLayerNew};
+use crate::mesh_layers::{ComputableLayer, BaseMeshLayer, RenderableLayer, LayerAttrMapper};
 use crate::pipelines::RenderPipeline;
 use renderer_common::render_modifier::SpatialData;
 use std::mem;
 use wgpu::{CommandEncoder, ComputePassDescriptor, RenderPass};
-use crate::mesh::mesh_instance_input::{AttrMapper, MeshInstanceInput};
+use crate::mesh::mesh_instance_input::{MeshInstanceInput};
 
 pub(crate) struct GeneralMeshLayer<I: MeshInstanceInput> {
     render_data_holder: RenderDataHolder<PositionedMesh<I>>,
     indirect: bool,
     pub disable_skip_mesh_feature: bool,
-    attr_map: AttrMapper<I>
+    attr_map: LayerAttrMapper<I>
 }
 
 impl<I: MeshInstanceInput> GeneralMeshLayer<I> {
-    pub fn new(indirect: bool, attr_map: AttrMapper<I>) -> Self {
+    pub fn new(indirect: bool, attr_map: LayerAttrMapper<I>) -> Self {
         GeneralMeshLayer {
             render_data_holder: RenderDataHolder::new(),
             indirect,
@@ -82,8 +82,8 @@ impl<I: MeshInstanceInput> BaseMeshLayer for GeneralMeshLayer<I> {
     }
 }
 
-impl<I: MeshInstanceInput> BaseMeshLayerNew<I> for GeneralMeshLayer<I> {
-    fn render_new(&mut self, render_pass: &mut RenderPass, render_pipeline: &mut impl RenderPipeline<I>, global_context: &mut GlobalContext) {
+impl<I: MeshInstanceInput> RenderableLayer<I> for GeneralMeshLayer<I> {
+    fn render(&mut self, render_pass: &mut RenderPass, render_pipeline: &mut impl RenderPipeline<I>, global_context: &mut GlobalContext) {
         render_pipeline.setup_render(render_pass, global_context);
         self.render_data_holder.run_mut_action(|mesh| {
             render_pipeline.setup_mesh_buffers(render_pass, mesh.get_mesh_buffers());
@@ -92,8 +92,8 @@ impl<I: MeshInstanceInput> BaseMeshLayerNew<I> for GeneralMeshLayer<I> {
     }
 }
 
-impl<I: MeshInstanceInput> BaseMeshComputeLayerNew<I> for GeneralMeshLayer<I> {
-    fn compute_new(&mut self, command_encoder: &mut CommandEncoder, render_pipeline: &mut impl RenderPipeline<I>, global_context: &mut GlobalContext) {
+impl<I: MeshInstanceInput> ComputableLayer<I> for GeneralMeshLayer<I> {
+    fn compute(&mut self, command_encoder: &mut CommandEncoder, render_pipeline: &mut impl RenderPipeline<I>, global_context: &mut GlobalContext) {
         let mut compute_pass = command_encoder.begin_compute_pass(&ComputePassDescriptor {
             label: Some("General Mesh Layer Compute Pass"),
             timestamp_writes: None,

--- a/renderer-gpu/src/mesh_layers/layers.rs
+++ b/renderer-gpu/src/mesh_layers/layers.rs
@@ -37,9 +37,7 @@ impl Layers {
         font: ttf_parser::Face<'static>,
     ) -> Layers {
         let feature_layers = FeatureLayers::new(world_shapes_feature_tags.clone(), |tag| {
-            GeneralMeshLayer::new(
-                tag.indirect
-            )
+            GeneralMeshLayer::new(tag.indirect, ShapeInstanceInput::from)
         });
         let text_feature_layers = FeatureLayers::new(
             vec![
@@ -50,6 +48,7 @@ impl Layers {
                 TextMeshLayer::new(
                     global_context,
                     font.clone(),
+                    Into::into
                 )
             },
         );
@@ -57,13 +56,13 @@ impl Layers {
         Layers {
             world_shapes_feature_tags,
             feature_layers,
-            mesh_layer: GeneralMeshLayer::new(false),
-            shape_layer: GeneralMeshLayer::new(false),
-            screen_shape_layer: ScreenShapeLayer::new(global_context),
-            shadow_map_layer: OrthoMeshLayer::new(true, false),
+            mesh_layer: GeneralMeshLayer::new(false, Into::into),
+            shape_layer: GeneralMeshLayer::new(false, Into::into),
+            screen_shape_layer: ScreenShapeLayer::new(global_context, Into::into),
+            shadow_map_layer: OrthoMeshLayer::new(true, false, Into::into),
             text_feature_layers,
-            preview_mesh_layer: OrthoMeshLayer::new(false, true),
-            post_process_layer: OrthoMeshLayer::new(true, false),
+            preview_mesh_layer: OrthoMeshLayer::new(false, true, Into::into),
+            post_process_layer: OrthoMeshLayer::new(true, false, Into::into),
         }
     }
 

--- a/renderer-gpu/src/mesh_layers/mod.rs
+++ b/renderer-gpu/src/mesh_layers/mod.rs
@@ -12,7 +12,7 @@ pub mod ortho_mesh_layer;
 pub mod feature_layers;
 
 #[derive(Default)]
-pub struct LayerAttrubute {
+pub struct LayerAttribute {
     pub(crate) position: [f32; 3],
     pub(crate) color_alpha: f32,
     pub(crate) matrix: [[f32; 4]; 4],
@@ -21,7 +21,7 @@ pub struct LayerAttrubute {
     pub(crate) screen_space: u32,
 }
 
-pub type LayerAttrMapper<I> = fn(LayerAttrubute) -> I;
+pub type LayerAttrMapper<I> = fn(LayerAttribute) -> I;
 
 pub trait BaseMeshLayer {
     fn update(&mut self, global_context: &mut GlobalContext);

--- a/renderer-gpu/src/mesh_layers/mod.rs
+++ b/renderer-gpu/src/mesh_layers/mod.rs
@@ -11,16 +11,28 @@ pub mod screen_shape_layer;
 pub mod ortho_mesh_layer;
 pub mod feature_layers;
 
+#[derive(Default)]
+pub struct LayerAttrubute {
+    pub(crate) position: [f32; 3],
+    pub(crate) color_alpha: f32,
+    pub(crate) matrix: [[f32; 4]; 4],
+    pub(crate) bbox: [f32; 4],
+    pub(crate) normal_scale: f32,
+    pub(crate) screen_space: u32,
+}
+
+pub type LayerAttrMapper<I> = fn(LayerAttrubute) -> I;
+
 pub trait BaseMeshLayer {
     fn update(&mut self, global_context: &mut GlobalContext);
 
     fn clear_by_key(&mut self, key: &str);
 }
 
-pub trait BaseMeshLayerNew<I: MeshInstanceInput> {
-    fn render_new(&mut self, _render_pass: &mut RenderPass, _render_pipeline: &mut impl RenderPipeline<I>, _global_context: &mut GlobalContext) {}
+pub trait RenderableLayer<I: MeshInstanceInput> {
+    fn render(&mut self, _render_pass: &mut RenderPass, _render_pipeline: &mut impl RenderPipeline<I>, _global_context: &mut GlobalContext) {}
 }
 
-pub trait BaseMeshComputeLayerNew<I: MeshInstanceInput> {
-    fn compute_new(&mut self, _command_encoder: &mut CommandEncoder, _render_pipeline: &mut impl RenderPipeline<I>, _global_context: &mut GlobalContext) {}
+pub trait ComputableLayer<I: MeshInstanceInput> {
+    fn compute(&mut self, _command_encoder: &mut CommandEncoder, _render_pipeline: &mut impl RenderPipeline<I>, _global_context: &mut GlobalContext) {}
 }

--- a/renderer-gpu/src/mesh_layers/ortho_mesh_layer.rs
+++ b/renderer-gpu/src/mesh_layers/ortho_mesh_layer.rs
@@ -2,7 +2,7 @@ use crate::buffer_pool::BufferPool;
 use crate::global_context::GlobalContext;
 use crate::mesh::InstanceBuffer;
 use crate::mesh::mesh::Mesh;
-use crate::mesh::mesh_instance_input::MeshInstanceInput;
+use crate::mesh::mesh_instance_input::{AttrMapper, CommonAttributes, MeshInstanceInput};
 use crate::mesh_buffers::MeshBuffers;
 use crate::mesh_layers::{BaseMeshLayer, BaseMeshLayerNew};
 use crate::pipelines::RenderPipeline;
@@ -11,6 +11,7 @@ use log::error;
 use wgpu::{RenderPass, TextureView};
 
 pub struct OrthoMeshLayer<I: MeshInstanceInput> {
+    attr_map: AttrMapper<I>,
     mesh: Option<Mesh>,
     instance_buffer: InstanceBuffer<I>,
     mesh_buffers: MeshBuffers,
@@ -20,8 +21,9 @@ pub struct OrthoMeshLayer<I: MeshInstanceInput> {
 }
 
 impl<I: MeshInstanceInput> OrthoMeshLayer<I> {
-    pub fn new(full_screen_mesh: bool, is_bottom_right: bool) -> Self {
+    pub fn new(full_screen_mesh: bool, is_bottom_right: bool, attr_map: AttrMapper<I>) -> Self {
         Self {
+            attr_map,
             mesh: None,
             instance_buffer: InstanceBuffer::default(),
             mesh_buffers: MeshBuffers::default(),
@@ -88,9 +90,14 @@ impl<I: MeshInstanceInput> OrthoMeshLayer<I> {
             0.0,
         ];
 
-        let attr = I::builder(position, 1.0, Mat4::IDENTITY.to_cols_array_2d())
-            .with_screen_space(1).build();
-
+        let attr = (self.attr_map)(CommonAttributes {
+            position,
+            color_alpha: 1.0,
+            matrix: Mat4::IDENTITY.to_cols_array_2d(),
+            screen_space: 1,
+            ..Default::default()
+        });
+       
         self.instance_buffer
             .update("quad_instance_buffer", global_context, &vec![attr]);
         self.mesh_buffers =

--- a/renderer-gpu/src/mesh_layers/ortho_mesh_layer.rs
+++ b/renderer-gpu/src/mesh_layers/ortho_mesh_layer.rs
@@ -4,7 +4,7 @@ use crate::mesh::InstanceBuffer;
 use crate::mesh::mesh::Mesh;
 use crate::mesh::mesh_instance_input::{MeshInstanceInput};
 use crate::mesh_buffers::MeshBuffers;
-use crate::mesh_layers::{BaseMeshLayer, LayerAttrMapper, LayerAttrubute, RenderableLayer};
+use crate::mesh_layers::{BaseMeshLayer, LayerAttrMapper, LayerAttribute, RenderableLayer};
 use crate::pipelines::RenderPipeline;
 use glam::Mat4;
 use log::error;
@@ -90,7 +90,7 @@ impl<I: MeshInstanceInput> OrthoMeshLayer<I> {
             0.0,
         ];
 
-        let attr = (self.attr_map)(LayerAttrubute {
+        let attr = (self.attr_map)(LayerAttribute {
             position,
             color_alpha: 1.0,
             matrix: Mat4::IDENTITY.to_cols_array_2d(),

--- a/renderer-gpu/src/mesh_layers/ortho_mesh_layer.rs
+++ b/renderer-gpu/src/mesh_layers/ortho_mesh_layer.rs
@@ -2,16 +2,16 @@ use crate::buffer_pool::BufferPool;
 use crate::global_context::GlobalContext;
 use crate::mesh::InstanceBuffer;
 use crate::mesh::mesh::Mesh;
-use crate::mesh::mesh_instance_input::{AttrMapper, CommonAttributes, MeshInstanceInput};
+use crate::mesh::mesh_instance_input::{MeshInstanceInput};
 use crate::mesh_buffers::MeshBuffers;
-use crate::mesh_layers::{BaseMeshLayer, BaseMeshLayerNew};
+use crate::mesh_layers::{BaseMeshLayer, LayerAttrMapper, LayerAttrubute, RenderableLayer};
 use crate::pipelines::RenderPipeline;
 use glam::Mat4;
 use log::error;
 use wgpu::{RenderPass, TextureView};
 
 pub struct OrthoMeshLayer<I: MeshInstanceInput> {
-    attr_map: AttrMapper<I>,
+    attr_map: LayerAttrMapper<I>,
     mesh: Option<Mesh>,
     instance_buffer: InstanceBuffer<I>,
     mesh_buffers: MeshBuffers,
@@ -21,7 +21,7 @@ pub struct OrthoMeshLayer<I: MeshInstanceInput> {
 }
 
 impl<I: MeshInstanceInput> OrthoMeshLayer<I> {
-    pub fn new(full_screen_mesh: bool, is_bottom_right: bool, attr_map: AttrMapper<I>) -> Self {
+    pub fn new(full_screen_mesh: bool, is_bottom_right: bool, attr_map: LayerAttrMapper<I>) -> Self {
         Self {
             attr_map,
             mesh: None,
@@ -90,7 +90,7 @@ impl<I: MeshInstanceInput> OrthoMeshLayer<I> {
             0.0,
         ];
 
-        let attr = (self.attr_map)(CommonAttributes {
+        let attr = (self.attr_map)(LayerAttrubute {
             position,
             color_alpha: 1.0,
             matrix: Mat4::IDENTITY.to_cols_array_2d(),
@@ -111,8 +111,8 @@ impl <I: MeshInstanceInput> BaseMeshLayer for OrthoMeshLayer<I> {
     fn clear_by_key(&mut self, _key: &str) {}
 }
 
-impl<I: MeshInstanceInput> BaseMeshLayerNew<I> for OrthoMeshLayer<I> {
-    fn render_new(
+impl<I: MeshInstanceInput> RenderableLayer<I> for OrthoMeshLayer<I> {
+    fn render(
         &mut self,
         render_pass: &mut RenderPass,
         render_pipeline: &mut impl RenderPipeline<I>,

--- a/renderer-gpu/src/mesh_layers/ortho_mesh_layer.rs
+++ b/renderer-gpu/src/mesh_layers/ortho_mesh_layer.rs
@@ -14,7 +14,7 @@ pub struct OrthoMeshLayer<I: MeshInstanceInput> {
     attr_map: LayerAttrMapper<I>,
     mesh: Option<Mesh>,
     instance_buffer: InstanceBuffer<I>,
-    mesh_buffers: MeshBuffers,
+    mesh_buffers: MeshBuffers<I>,
     full_screen_mesh: bool,
     is_bottom_right: bool,
     texture_view: Option<TextureView>,
@@ -101,7 +101,7 @@ impl<I: MeshInstanceInput> OrthoMeshLayer<I> {
         self.instance_buffer
             .update("quad_instance_buffer", global_context, &vec![attr]);
         self.mesh_buffers =
-            MeshBuffers::builder().with_instance_buffer(self.instance_buffer.buffer.clone())
+            MeshBuffers::builder().with_instance_buffer(&self.instance_buffer)
     }
 }
 

--- a/renderer-gpu/src/mesh_layers/screen_shape_layer.rs
+++ b/renderer-gpu/src/mesh_layers/screen_shape_layer.rs
@@ -4,9 +4,9 @@ use crate::draw_commands::mesh2d_draw_command::Mesh2dDrawCommand;
 use crate::global_context::GlobalContext;
 use crate::mesh::InstanceBuffer;
 use crate::mesh::mesh::Mesh;
-use crate::mesh::mesh_instance_input::{AttrMapper, CommonAttributes, MeshInstanceInput};
+use crate::mesh::mesh_instance_input::{MeshInstanceInput};
 use crate::mesh_buffers::MeshBuffers;
-use crate::mesh_layers::{BaseMeshLayer, BaseMeshLayerNew};
+use crate::mesh_layers::{BaseMeshLayer, LayerAttrMapper, RenderableLayer};
 use crate::pipelines::RenderPipeline;
 use crate::view_projection::ViewProjection;
 use geo_types::point;
@@ -21,7 +21,7 @@ use wgpu::RenderPass;
 
 // TODO ScreenMeshLayer and GeneralMeshLayer could be combined somehow.
 pub(crate) struct ScreenShapeLayer<I: MeshInstanceInput> {
-    attr_map: AttrMapper<I>,
+    attr_map: LayerAttrMapper<I>,
     meshes: HashMap<String, (Mesh, InstanceBuffer<I>, MeshBuffers)>,
     collision_task_controller: CollisionTaskController<
         (ShapeInfo, f32, String),
@@ -35,7 +35,7 @@ struct ShapeInfo {
 }
 
 impl<I: MeshInstanceInput> ScreenShapeLayer<I> {
-    pub fn new(global_context: &mut GlobalContext, attr_map: AttrMapper<I>) -> Self {
+    pub fn new(global_context: &mut GlobalContext, attr_map: LayerAttrMapper<I>) -> Self {
         let (task_wrapper, collision_task_controller) = CollisionTaskWrapper::new();
         let task = ScreenMeshCollisionHandler::new(task_wrapper);
         global_context.collider.register_task(Box::new(task));
@@ -130,8 +130,8 @@ impl<I: MeshInstanceInput> BaseMeshLayer for ScreenShapeLayer<I> {
     }
 }
 
-impl<I: MeshInstanceInput> BaseMeshLayerNew<I> for ScreenShapeLayer<I> {
-    fn render_new(&mut self, render_pass: &mut RenderPass, render_pipeline: &mut impl RenderPipeline<I>, global_context: &mut GlobalContext) {
+impl<I: MeshInstanceInput> RenderableLayer<I> for ScreenShapeLayer<I> {
+    fn render(&mut self, render_pass: &mut RenderPass, render_pipeline: &mut impl RenderPipeline<I>, global_context: &mut GlobalContext) {
         render_pipeline.setup_render(render_pass, global_context);
         self.meshes.iter().for_each(|(_, (mesh, instance_buf, mesh_buffers))| {
             let instance_count = instance_buf.length;

--- a/renderer-gpu/src/mesh_layers/screen_shape_layer.rs
+++ b/renderer-gpu/src/mesh_layers/screen_shape_layer.rs
@@ -22,7 +22,7 @@ use wgpu::RenderPass;
 // TODO ScreenMeshLayer and GeneralMeshLayer could be combined somehow.
 pub(crate) struct ScreenShapeLayer<I: MeshInstanceInput> {
     attr_map: LayerAttrMapper<I>,
-    meshes: HashMap<String, (Mesh, InstanceBuffer<I>, MeshBuffers)>,
+    meshes: HashMap<String, (Mesh, InstanceBuffer<I>, MeshBuffers<I>)>,
     collision_task_controller: CollisionTaskController<
         (ShapeInfo, f32, String),
         HashMap<String, Vec<(DVec3, f32)>>,
@@ -121,7 +121,7 @@ impl<I: MeshInstanceInput> BaseMeshLayer for ScreenShapeLayer<I> {
                     global_context,
                     &attrs,
                 );
-                *mesh_buffers = MeshBuffers::builder().with_instance_buffer(instance_buffer.buffer.clone());
+                *mesh_buffers = MeshBuffers::builder().with_instance_buffer(instance_buffer);
             });
     }
     

--- a/renderer-gpu/src/mesh_layers/screen_shape_layer.rs
+++ b/renderer-gpu/src/mesh_layers/screen_shape_layer.rs
@@ -4,7 +4,7 @@ use crate::draw_commands::mesh2d_draw_command::Mesh2dDrawCommand;
 use crate::global_context::GlobalContext;
 use crate::mesh::InstanceBuffer;
 use crate::mesh::mesh::Mesh;
-use crate::mesh::mesh_instance_input::MeshInstanceInput;
+use crate::mesh::mesh_instance_input::{AttrMapper, CommonAttributes, MeshInstanceInput};
 use crate::mesh_buffers::MeshBuffers;
 use crate::mesh_layers::{BaseMeshLayer, BaseMeshLayerNew};
 use crate::pipelines::RenderPipeline;
@@ -21,6 +21,7 @@ use wgpu::RenderPass;
 
 // TODO ScreenMeshLayer and GeneralMeshLayer could be combined somehow.
 pub(crate) struct ScreenShapeLayer<I: MeshInstanceInput> {
+    attr_map: AttrMapper<I>,
     meshes: HashMap<String, (Mesh, InstanceBuffer<I>, MeshBuffers)>,
     collision_task_controller: CollisionTaskController<
         (ShapeInfo, f32, String),
@@ -34,11 +35,12 @@ struct ShapeInfo {
 }
 
 impl<I: MeshInstanceInput> ScreenShapeLayer<I> {
-    pub fn new(global_context: &mut GlobalContext) -> Self {
+    pub fn new(global_context: &mut GlobalContext, attr_map: AttrMapper<I>) -> Self {
         let (task_wrapper, collision_task_controller) = CollisionTaskWrapper::new();
         let task = ScreenMeshCollisionHandler::new(task_wrapper);
         global_context.collider.register_task(Box::new(task));
         ScreenShapeLayer {
+            attr_map,
             meshes: HashMap::new(),
             collision_task_controller,
         }
@@ -107,6 +109,7 @@ impl<I: MeshInstanceInput> BaseMeshLayer for ScreenShapeLayer<I> {
                 if let Some(pos_alpha) = hm.get(key) {
                     I::fill_attrs(
                         &mut attrs,
+                        self.attr_map,
                         &cs_offset,
                         pos_alpha,
                         &SpatialData::new(),

--- a/renderer-gpu/src/mesh_layers/text_mesh_layer.rs
+++ b/renderer-gpu/src/mesh_layers/text_mesh_layer.rs
@@ -1,5 +1,5 @@
 use crate::global_context::GlobalContext;
-use crate::mesh::mesh_instance_input::MeshInstanceInput;
+use crate::mesh::mesh_instance_input::{AttrMapper, MeshInstanceInput};
 use crate::mesh_layers::{BaseMeshLayer, BaseMeshLayerNew};
 use crate::pipelines::RenderPipeline;
 use crate::text::text_renderer::TextRenderer;
@@ -15,9 +15,10 @@ impl<I: MeshInstanceInput> TextMeshLayer<I> {
     pub fn new(
         global_context: &mut GlobalContext,
         font: rustybuzz::ttf_parser::Face<'static>,
+        attr_map: AttrMapper<I>
     ) -> Self {
         Self {
-            text_renderer: TextRenderer::new(global_context, font),
+            text_renderer: TextRenderer::new(global_context, font, attr_map),
         }
     }
 

--- a/renderer-gpu/src/mesh_layers/text_mesh_layer.rs
+++ b/renderer-gpu/src/mesh_layers/text_mesh_layer.rs
@@ -1,6 +1,6 @@
 use crate::global_context::GlobalContext;
-use crate::mesh::mesh_instance_input::{AttrMapper, MeshInstanceInput};
-use crate::mesh_layers::{BaseMeshLayer, BaseMeshLayerNew};
+use crate::mesh::mesh_instance_input::{MeshInstanceInput};
+use crate::mesh_layers::{BaseMeshLayer, LayerAttrMapper, RenderableLayer};
 use crate::pipelines::RenderPipeline;
 use crate::text::text_renderer::TextRenderer;
 use renderer_common::geometry_data::{LineData, TextData};
@@ -15,7 +15,7 @@ impl<I: MeshInstanceInput> TextMeshLayer<I> {
     pub fn new(
         global_context: &mut GlobalContext,
         font: rustybuzz::ttf_parser::Face<'static>,
-        attr_map: AttrMapper<I>
+        attr_map: LayerAttrMapper<I>
     ) -> Self {
         Self {
             text_renderer: TextRenderer::new(global_context, font, attr_map),
@@ -65,8 +65,8 @@ impl<I: MeshInstanceInput> BaseMeshLayer for TextMeshLayer<I> {
     }
 }
 
-impl <I: MeshInstanceInput> BaseMeshLayerNew<I> for TextMeshLayer<I> {
-    fn render_new(&mut self, render_pass: &mut RenderPass, render_pipeline: &mut impl RenderPipeline<I>, global_context: &mut GlobalContext) {
+impl <I: MeshInstanceInput> RenderableLayer<I> for TextMeshLayer<I> {
+    fn render(&mut self, render_pass: &mut RenderPass, render_pipeline: &mut impl RenderPipeline<I>, global_context: &mut GlobalContext) {
         render_pipeline.setup_render(render_pass, global_context);
         self.text_renderer.render(render_pass, global_context);
     }

--- a/renderer-gpu/src/pass_nodes/g_buffer_pass_node.rs
+++ b/renderer-gpu/src/pass_nodes/g_buffer_pass_node.rs
@@ -1,6 +1,6 @@
 use crate::global_context::GlobalContext;
 use crate::mesh_layers::layers::Layers;
-use crate::mesh_layers::BaseMeshLayerNew;
+use crate::mesh_layers::RenderableLayer;
 use crate::pass_nodes::PassNode;
 use crate::pipelines::g_buf_pipeline::GBufPipeline;
 use crate::texture_view_resources::TextureViewKind;
@@ -122,6 +122,6 @@ impl PassNode for GBufferPassNode {
 
         let mut render_pass = encoder.begin_render_pass(&descriptor);
 
-        layers.mesh_layer.render_new(&mut render_pass, &mut self.g_buf_pipeline, global_context);
+        layers.mesh_layer.render(&mut render_pass, &mut self.g_buf_pipeline, global_context);
     }
 }

--- a/renderer-gpu/src/pass_nodes/main_pass_node.rs
+++ b/renderer-gpu/src/pass_nodes/main_pass_node.rs
@@ -1,5 +1,5 @@
 use crate::global_context::{GlobalContext};
-use crate::mesh_layers::BaseMeshLayerNew;
+use crate::mesh_layers::RenderableLayer;
 use crate::mesh_layers::layers::Layers;
 use crate::pass_nodes::{BACKGROUND_ATTACHMENT_COLOR, PassNode};
 use crate::pipelines::mesh_pipeline::MeshPipeline;
@@ -161,40 +161,40 @@ impl PassNode for MainPassNode {
         let mut render_pass = encoder.begin_render_pass(&descriptor);
         
         layers.shape_layer.disable_skip_mesh_feature = false;
-        layers.shape_layer.render_new(
+        layers.shape_layer.render(
             &mut render_pass,
             &mut self.default_shape_pipeline,
             global_context,
         );
 
-        layers.mesh_layer.render_new(
+        layers.mesh_layer.render(
             &mut render_pass,
             &mut self.default_mesh_pipeline,
             global_context,
         );
 
         if global_context.is_shadow_mapping_enabled() {
-            layers.shadow_map_layer.render_new(
+            layers.shadow_map_layer.render(
                 &mut render_pass,
                 &mut self.shadow_map_screen_mesh_pipeline,
                 global_context,
             );
         }
         if global_context.is_ssao_enabled() {
-            layers.post_process_layer.render_new(
+            layers.post_process_layer.render(
                 &mut render_pass,
                 &mut self.post_process_screen_mesh_pipeline,
                 global_context,
             );
         }
-        layers.screen_shape_layer.render_new(
+        layers.screen_shape_layer.render(
             &mut render_pass,
             &mut self.screen_shape_pipeline,
             global_context,
         );
 
         layers.text_feature_layers.with_layer(|layer| {
-            layer.render_new(
+            layer.render(
                 &mut render_pass,
                 &mut self.text_screen_mesh_pipeline,
                 global_context,
@@ -205,12 +205,12 @@ impl PassNode for MainPassNode {
             .iter_mut()
             .for_each(|(feature_tag, shape_pipeline)| {
                 if let Some(layer) = layers.feature_layers.get_layer(feature_tag) {
-                    layer.render_new(&mut render_pass, shape_pipeline, global_context)
+                    layer.render(&mut render_pass, shape_pipeline, global_context)
                 }
             });
 
         if global_context.preview_type().is_enabled() {
-            layers.preview_mesh_layer.render_new(
+            layers.preview_mesh_layer.render(
                 &mut render_pass,
                 &mut self.preview_screen_mesh_pipeline,
                 global_context,

--- a/renderer-gpu/src/pass_nodes/main_pass_node.rs
+++ b/renderer-gpu/src/pass_nodes/main_pass_node.rs
@@ -14,7 +14,7 @@ pub(crate) struct MainPassNode {
     depth_texture_view: TextureView,
     default_mesh_pipeline: MeshPipeline,
     default_shape_pipeline: ShapePipeline,
-    screen_shape_layer: ShapePipeline,
+    screen_shape_pipeline: ShapePipeline,
     feature_shape_pipelines: Vec<(String, ShapePipeline)>,
     preview_screen_mesh_pipeline: ScreenMeshPipeline,
     text_screen_mesh_pipeline: ScreenMeshPipeline,
@@ -36,7 +36,7 @@ impl MainPassNode {
         let default_mesh_pipeline = MeshPipeline::new(global_context, true, true, true);
         let default_shape_pipeline = ShapePipeline::new(global_context, None, false, true);
 
-        let screen_shape_layer =
+        let screen_shape_pipeline =
             ShapePipeline::new(global_context, Some("vs_main_screen"), false, false);
 
         let mut preview_screen_mesh_pipeline = ScreenMeshPipeline::new(
@@ -108,7 +108,7 @@ impl MainPassNode {
             ),
             default_mesh_pipeline,
             default_shape_pipeline,
-            screen_shape_layer,
+            screen_shape_pipeline: screen_shape_pipeline,
             text_screen_mesh_pipeline,
             feature_shape_pipelines,
             preview_screen_mesh_pipeline,
@@ -189,7 +189,7 @@ impl PassNode for MainPassNode {
         }
         layers.screen_shape_layer.render_new(
             &mut render_pass,
-            &mut self.screen_shape_layer,
+            &mut self.screen_shape_pipeline,
             global_context,
         );
 

--- a/renderer-gpu/src/pass_nodes/prepass_node.rs
+++ b/renderer-gpu/src/pass_nodes/prepass_node.rs
@@ -1,6 +1,6 @@
 use crate::global_context::GlobalContext;
 use crate::mesh_layers::layers::Layers;
-use crate::mesh_layers::BaseMeshComputeLayerNew;
+use crate::mesh_layers::ComputableLayer;
 use crate::pass_nodes::PassNode;
 use crate::pipelines::shape_pipeline::ShapePipeline;
 use renderer_common::WorldShapeFeatureLayerTag;
@@ -47,7 +47,7 @@ impl PassNode for PrepassNode {
             .iter_mut()
             .for_each(|(feature_tag, shape_pipeline)| {
                 if let Some(layer) = layers.feature_layers.get_layer(feature_tag) {
-                    layer.compute_new(encoder, shape_pipeline, global_context)
+                    layer.compute(encoder, shape_pipeline, global_context)
                 }
             });
     }

--- a/renderer-gpu/src/pass_nodes/render_to_texture_pass_node.rs
+++ b/renderer-gpu/src/pass_nodes/render_to_texture_pass_node.rs
@@ -1,5 +1,5 @@
 use crate::global_context::GlobalContext;
-use crate::mesh_layers::BaseMeshLayerNew;
+use crate::mesh_layers::RenderableLayer;
 use crate::mesh_layers::layers::Layers;
 use crate::pass_nodes::{BACKGROUND_ATTACHMENT_COLOR, PassNode};
 use crate::pipelines::shape_pipeline::ShapePipeline;
@@ -77,12 +77,12 @@ impl PassNode for RenderToTexturePassNode {
         layers.shape_layer.disable_skip_mesh_feature = true;
         layers
             .shape_layer
-            .render_new(&mut render_pass, &mut self.shape_pipeline, global_context);
+            .render(&mut render_pass, &mut self.shape_pipeline, global_context);
         self.feature_shape_pipelines
             .iter_mut()
             .for_each(|(feature_tag, shape_pipeline)| {
                 if let Some(layer) = layers.feature_layers.get_layer(feature_tag) {
-                    layer.render_new(&mut render_pass, shape_pipeline, global_context)
+                    layer.render(&mut render_pass, shape_pipeline, global_context)
                 }
             });
     }

--- a/renderer-gpu/src/pass_nodes/shadow_pre_pass.rs
+++ b/renderer-gpu/src/pass_nodes/shadow_pre_pass.rs
@@ -1,6 +1,6 @@
 use crate::global_context::GlobalContext;
 use crate::mesh_layers::layers::Layers;
-use crate::mesh_layers::BaseMeshLayerNew;
+use crate::mesh_layers::RenderableLayer;
 use crate::pass_nodes::PassNode;
 use crate::pipelines::fill_shadow_map_pipeline::FillShadowMapPipeline;
 use crate::texture_view_resources::TextureViewKind;
@@ -46,7 +46,7 @@ impl PassNode for ShadowPrepass {
             };
 
             let mut render_pass = encoder.begin_render_pass(&descriptor);
-            layers.mesh_layer.render_new(&mut render_pass, &mut self.fill_shadow_map_pipeline, global_context)
+            layers.mesh_layer.render(&mut render_pass, &mut self.fill_shadow_map_pipeline, global_context)
         }
     }
 }

--- a/renderer-gpu/src/pipelines/mod.rs
+++ b/renderer-gpu/src/pipelines/mod.rs
@@ -12,9 +12,9 @@ pub mod g_buf_pipeline;
 pub trait RenderPipeline<InstanceInputType: MeshInstanceInput> {
     fn setup_compute(&mut self, _compute_pass: &mut ComputePass, _global_context: &GlobalContext) {}
     fn compute_mesh(&mut self, _compute_pass: &mut ComputePass,
-                    _mesh: &MeshBuffers) {}
+                    _mesh: &MeshBuffers<InstanceInputType>) {}
     fn setup_render(&mut self, render_pass: &mut RenderPass, global_context: &GlobalContext);
-    fn setup_mesh_buffers(&mut self, render_pass: &mut RenderPass, mesh_buffers: &MeshBuffers) {
+    fn setup_mesh_buffers(&mut self, render_pass: &mut RenderPass, mesh_buffers: &MeshBuffers<InstanceInputType>) {
         // by default all instances go to vertex buffer slot 1
         if let Some(buffer) = mesh_buffers.instance_buffer() {
             render_pass.set_vertex_buffer(1, buffer.slice(..));

--- a/renderer-gpu/src/pipelines/shape_pipeline.rs
+++ b/renderer-gpu/src/pipelines/shape_pipeline.rs
@@ -248,7 +248,7 @@ impl RenderPipeline<ShapeInstanceInput> for ShapePipeline {
 
     fn compute_mesh(&mut self,
                     compute_pass: &mut ComputePass,
-                    mesh_buffers: &MeshBuffers) {
+                    mesh_buffers: &MeshBuffers<ShapeInstanceInput>) {
         if self.indirect {
             if let Some(instance_args_buffer) = mesh_buffers.args_buffer_with_id() &&
                 let Some(culled_buffer) = mesh_buffers.culled_buffer_with_id() &&
@@ -302,7 +302,7 @@ impl RenderPipeline<ShapeInstanceInput> for ShapePipeline {
         }
     }
 
-    fn setup_mesh_buffers(&mut self, render_pass: &mut RenderPass, mesh_buffers: &MeshBuffers) {
+    fn setup_mesh_buffers(&mut self, render_pass: &mut RenderPass, mesh_buffers: &MeshBuffers<ShapeInstanceInput>) {
         if self.indirect && let Some(instance_buffer) = mesh_buffers.instance_buffer_with_id()
             && let Some(culled_buffer) = mesh_buffers.culled_buffer_with_id() {
             let instance_bind_group = self.bind_group_cache.get_bind_group_or_create(

--- a/renderer-gpu/src/text/text_renderer.rs
+++ b/renderer-gpu/src/text/text_renderer.rs
@@ -2,7 +2,7 @@ use crate::buffer_pool::BufferPool;
 use crate::collider::{ColliderTask, CollisionTaskController, CollisionTaskWrapper};
 use crate::global_context::GlobalContext;
 use crate::mesh::InstanceBuffer;
-use crate::mesh::mesh_instance_input::MeshInstanceInput;
+use crate::mesh::mesh_instance_input::{AttrMapper, CommonAttributes, MeshInstanceInput};
 use crate::mesh_layers::render_data_holder::RenderDataHolder;
 use crate::text::default_face_wrapper::DefaultFaceWrapper;
 use crate::text::glyph_cache::GlyphCache;
@@ -32,6 +32,7 @@ pub struct GlyphData {
 }
 
 pub struct TextRenderer<I: MeshInstanceInput> {
+    attr_map: AttrMapper<I>,
     collision_task_controller:
         CollisionTaskController<TextData, FxHashMap<GlyphId, Vec<GlyphData>>>,
     instance_buffer_map: FxHashMap<GlyphId, InstanceBuffer<I>>,
@@ -44,6 +45,7 @@ impl<I: MeshInstanceInput> TextRenderer<I> {
     pub fn new(
         global_context: &mut GlobalContext,
         font: rustybuzz::ttf_parser::Face<'static>,
+        attr_map: AttrMapper<I>
     ) -> Self {
         let default_face = Arc::new(DefaultFaceWrapper::new(font));
         let (task_wrapper, collision_task_controller) = CollisionTaskWrapper::new();
@@ -52,6 +54,7 @@ impl<I: MeshInstanceInput> TextRenderer<I> {
         let task = TextRendererCollisionHandler::new(Arc::clone(&default_face), task_wrapper);
         global_context.collider.register_task(Box::new(task));
         Self {
+            attr_map,
             collision_task_controller,
             instance_buffer_map: FxHashMap::default(),
             glyph_cache,
@@ -80,10 +83,14 @@ impl<I: MeshInstanceInput> TextRenderer<I> {
                 if !glyph_data.screen_space {
                     position -= dvec3(cs_offset.x, cs_offset.y, 0.0)
                 }
-                let instance_input = I::builder(position.as_vec3().into(),
-                                                glyph_data.alpha,
-                                                glyph_data.matrix.to_cols_array_2d(),
-                ).with_screen_space(glyph_data.screen_space.into()).build();
+
+                let instance_input = (self.attr_map)(CommonAttributes {
+                    position: position.as_vec3().into(),
+                    color_alpha: glyph_data.alpha,
+                    matrix: glyph_data.matrix.to_cols_array_2d(),
+                    screen_space: glyph_data.screen_space.into(),
+                    ..Default::default()
+                });
                 attrs.push(instance_input);
             });
 

--- a/renderer-gpu/src/text/text_renderer.rs
+++ b/renderer-gpu/src/text/text_renderer.rs
@@ -2,7 +2,7 @@ use crate::buffer_pool::BufferPool;
 use crate::collider::{ColliderTask, CollisionTaskController, CollisionTaskWrapper};
 use crate::global_context::GlobalContext;
 use crate::mesh::InstanceBuffer;
-use crate::mesh::mesh_instance_input::{AttrMapper, CommonAttributes, MeshInstanceInput};
+use crate::mesh::mesh_instance_input::{MeshInstanceInput};
 use crate::mesh_layers::render_data_holder::RenderDataHolder;
 use crate::text::default_face_wrapper::DefaultFaceWrapper;
 use crate::text::glyph_cache::GlyphCache;
@@ -21,6 +21,7 @@ use std::f32::consts::PI;
 use std::mem;
 use std::sync::Arc;
 use wgpu::RenderPass;
+use crate::mesh_layers::{LayerAttrMapper, LayerAttrubute};
 
 #[derive(Clone)]
 pub struct GlyphData {
@@ -32,7 +33,7 @@ pub struct GlyphData {
 }
 
 pub struct TextRenderer<I: MeshInstanceInput> {
-    attr_map: AttrMapper<I>,
+    attr_map: LayerAttrMapper<I>,
     collision_task_controller:
         CollisionTaskController<TextData, FxHashMap<GlyphId, Vec<GlyphData>>>,
     instance_buffer_map: FxHashMap<GlyphId, InstanceBuffer<I>>,
@@ -45,7 +46,7 @@ impl<I: MeshInstanceInput> TextRenderer<I> {
     pub fn new(
         global_context: &mut GlobalContext,
         font: rustybuzz::ttf_parser::Face<'static>,
-        attr_map: AttrMapper<I>
+        attr_map: LayerAttrMapper<I>
     ) -> Self {
         let default_face = Arc::new(DefaultFaceWrapper::new(font));
         let (task_wrapper, collision_task_controller) = CollisionTaskWrapper::new();
@@ -84,7 +85,7 @@ impl<I: MeshInstanceInput> TextRenderer<I> {
                     position -= dvec3(cs_offset.x, cs_offset.y, 0.0)
                 }
 
-                let instance_input = (self.attr_map)(CommonAttributes {
+                let instance_input = (self.attr_map)(LayerAttrubute {
                     position: position.as_vec3().into(),
                     color_alpha: glyph_data.alpha,
                     matrix: glyph_data.matrix.to_cols_array_2d(),

--- a/renderer-gpu/src/text/text_renderer.rs
+++ b/renderer-gpu/src/text/text_renderer.rs
@@ -21,7 +21,7 @@ use std::f32::consts::PI;
 use std::mem;
 use std::sync::Arc;
 use wgpu::RenderPass;
-use crate::mesh_layers::{LayerAttrMapper, LayerAttrubute};
+use crate::mesh_layers::{LayerAttrMapper, LayerAttribute};
 
 #[derive(Clone)]
 pub struct GlyphData {
@@ -85,7 +85,7 @@ impl<I: MeshInstanceInput> TextRenderer<I> {
                     position -= dvec3(cs_offset.x, cs_offset.y, 0.0)
                 }
 
-                let instance_input = (self.attr_map)(LayerAttrubute {
+                let instance_input = (self.attr_map)(LayerAttribute {
                     position: position.as_vec3().into(),
                     color_alpha: glyph_data.alpha,
                     matrix: glyph_data.matrix.to_cols_array_2d(),

--- a/renderer-gpu/src/vertex_attrs.rs
+++ b/renderer-gpu/src/vertex_attrs.rs
@@ -92,7 +92,7 @@ impl VertexAttrib for MeshVertex {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
+#[derive(Default, Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
 pub struct GeneralInstanceInput {
     pub(crate) position: [f32; 3],
     pub(crate) color_alpha: f32,
@@ -113,7 +113,7 @@ impl VertexAttrib for GeneralInstanceInput {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
+#[derive(Default, Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
 pub struct ShapeInstanceInput {
     pub(crate) position: [f32; 3],
     pub(crate) color_alpha: f32,
@@ -138,7 +138,7 @@ impl VertexAttrib for ShapeInstanceInput {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
+#[derive(Default, Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
 pub struct ScreenShapeInstanceInput {
     pub(crate) position: [f32; 3],
     pub(crate) color_alpha: f32,


### PR DESCRIPTION
## Summary
1. Refactored the way how `MeshInstanceInput` being created and used
2. `MeshBuffers` are now specified by generic `MeshInstanceInput` for better compile checks
3. Renaming