### PR TITLE
Fix BindGroups growing for indirect buffers + report mechanism

### DIFF
--- a/renderer-gpu/src/mesh/mod.rs
+++ b/renderer-gpu/src/mesh/mod.rs
@@ -1,7 +1,7 @@
 use crate::global_context::GlobalContext;
+use crate::mesh_buffers::BufferWithId;
 use bytemuck::Pod;
 use std::marker::PhantomData;
-use wgpu::Buffer;
 use wgpu::util::DeviceExt;
 
 pub mod mesh;
@@ -9,7 +9,7 @@ pub mod mesh_instance_input;
 pub mod positioned_mesh;
 
 pub struct InstanceBuffer<T: Pod> {
-    pub buffer: Option<Buffer>,
+    pub buffer_with_id: Option<BufferWithId>,
     pub length: usize,
     max_length: usize,
     _phantom_data: PhantomData<T>,
@@ -18,7 +18,7 @@ pub struct InstanceBuffer<T: Pod> {
 impl<T: Pod> Default for InstanceBuffer<T> {
     fn default() -> Self {
         InstanceBuffer {
-            buffer: None,
+            buffer_with_id: None,
             length: 0,
             max_length: 0,
             _phantom_data: Default::default(),
@@ -32,12 +32,12 @@ impl<T: Pod> InstanceBuffer<T> {
         // TODO benchmark create_buffer_init vs write_buffer vs write_buffer_with
         let data_len = data.len();
         if data_len <= self.max_length
-            && let Some(buffer) = self.buffer.as_ref()
+            && let Some(buffer_with_id) = self.buffer_with_id.as_ref()
         {
             // write only non-zero data, if zero then only write once
             if data_len != 0 || data_len != self.length {
                 let queue = global_context.queue();
-                queue.write_buffer(buffer, 0, bytemuck::cast_slice(data.as_slice()));
+                queue.write_buffer(buffer_with_id.buffer(), 0, bytemuck::cast_slice(data.as_slice()));
                 // FIXME write_buffer_with doesn't work as expected, why?
                 // if let Some(mut buf_view) = queue.write_buffer_with(buffer, 0, data_size) {
                 //     buf_view.copy_from_slice(data);
@@ -45,12 +45,12 @@ impl<T: Pod> InstanceBuffer<T> {
             }
         } else {
             let device = global_context.device();
-            self.buffer = Some(
-                device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            self.buffer_with_id = Some(
+                BufferWithId::from(device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
                     label: Some(label),
                     contents: bytemuck::cast_slice(data.as_slice()),
-                    usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::STORAGE |wgpu::BufferUsages::COPY_DST,
-                }),
+                    usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+                })),
             );
         }
         self.length = data.len();

--- a/renderer-gpu/src/mesh/positioned_mesh.rs
+++ b/renderer-gpu/src/mesh/positioned_mesh.rs
@@ -104,7 +104,7 @@ impl<T: MeshInstanceInput> PositionedMesh<T> {
                 } else {
                     self.mesh.index_buf.1
                 };
-                let params: InternalIndirectBufParams = (instance_buffer_length, index_count, index_count);
+                let params: InternalIndirectBufParams = (instance_buffer_length, instance_count, index_count);
                 if self.indirect_prev_params != params {
                     let culled_buffer = Some(global_context.device().create_buffer_init(&wgpu::util::BufferInitDescriptor {
                         label: Some("Culled Buffer"),

--- a/renderer-gpu/src/mesh/positioned_mesh.rs
+++ b/renderer-gpu/src/mesh/positioned_mesh.rs
@@ -1,16 +1,17 @@
 use crate::global_context::GlobalContext;
 use crate::mesh::InstanceBuffer;
 use crate::mesh::mesh::Mesh;
-use crate::mesh::mesh_instance_input::{MeshInstanceInput};
+use crate::mesh::mesh_instance_input::MeshInstanceInput;
 use crate::mesh_buffers::MeshBuffers;
+use crate::mesh_layers::LayerAttrMapper;
 use crate::utils::ReceiverExt;
 use glam::DVec3;
 use renderer_common::render_modifier::SpatialData;
 use tokio::sync::broadcast::Receiver;
 use wgpu::util::{DeviceExt, DrawIndexedIndirectArgs};
 use wgpu::{ComputePass, RenderPass};
-use crate::mesh_layers::LayerAttrMapper;
 
+type InternalIndirectBufParams = (usize, usize, usize);
 pub struct PositionedMesh<T: MeshInstanceInput> {
     mesh: Mesh,
     attr_map: LayerAttrMapper<T>,
@@ -21,7 +22,8 @@ pub struct PositionedMesh<T: MeshInstanceInput> {
     spatial_rx: Receiver<SpatialData>,
     original_spatial_data: SpatialData,
     original_instance_positions_alpha: Vec<(DVec3, f32)>,
-    mesh_buffers: MeshBuffers<T>
+    mesh_buffers: MeshBuffers<T>,
+    indirect_prev_params: InternalIndirectBufParams,
 }
 
 impl Mesh {
@@ -56,6 +58,7 @@ impl<T: MeshInstanceInput> PositionedMesh<T> {
             original_instance_positions_alpha: instance_positions_alpha
                 .unwrap_or(vec![(DVec3::new(0.0, 0.0, 0.0), 1f32)]),
             mesh_buffers: MeshBuffers::default(),
+            indirect_prev_params: InternalIndirectBufParams::default(),
         }
     }
 
@@ -87,14 +90,10 @@ impl<T: MeshInstanceInput> PositionedMesh<T> {
                 &self.attrs,
             );
 
+            self.mesh_buffers = self.mesh_buffers.clone()
+                .with_instance_buffer(&self.instance_buffer);
             if indirect {
                 let instance_buffer_length = self.get_instance_buffer_length();
-                let culled_buffer = global_context.device().create_buffer_init(&wgpu::util::BufferInitDescriptor {
-                    label: Some("Culled Buffer"),
-                    contents: bytemuck::cast_slice(&vec![0; instance_buffer_length]),
-                    usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
-                });
-                
                 let instance_count = if self.attrs.len() <= 2 {
                     self.attrs.len() * instance_buffer_length
                 } else {
@@ -105,27 +104,32 @@ impl<T: MeshInstanceInput> PositionedMesh<T> {
                 } else {
                     self.mesh.index_buf.1
                 };
-                // instances_args_buffer has to be reset before computing
-                let indirect_args_struct = DrawIndexedIndirectArgs {
-                    index_count: index_count as u32,
-                    instance_count: instance_count as u32,
-                    first_index: 0,
-                    base_vertex: 0,
-                    first_instance: 0,
-                };
-                let indirect_args = global_context.device().create_buffer_init(&wgpu::util::BufferInitDescriptor {
-                    label: Some("indirect args"),
-                    contents: indirect_args_struct.as_bytes(),
-                    usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::INDIRECT |wgpu::BufferUsages::COPY_DST,
-                });
+                let params: InternalIndirectBufParams = (instance_buffer_length, index_count, index_count);
+                if self.indirect_prev_params != params {
+                    let culled_buffer = Some(global_context.device().create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                        label: Some("Culled Buffer"),
+                        contents: bytemuck::cast_slice(&vec![0; instance_buffer_length]),
+                        usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+                    }));
 
-                self.mesh_buffers = MeshBuffers::builder()
-                    .with_instance_buffer(&self.instance_buffer)
-                    .with_culled_and_args_buffer(Some(culled_buffer), Some(indirect_args))
+                    // instances_args_buffer has to be reset before computing
+                    let indirect_args_struct = DrawIndexedIndirectArgs {
+                        index_count: index_count as u32,
+                        instance_count: instance_count as u32,
+                        first_index: 0,
+                        base_vertex: 0,
+                        first_instance: 0,
+                    };
+                    let indirect_args = Some(global_context.device().create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                        label: Some("indirect args"),
+                        contents: indirect_args_struct.as_bytes(),
+                        usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::INDIRECT | wgpu::BufferUsages::COPY_DST,
+                    }));
 
-            } else {
-                self.mesh_buffers = MeshBuffers::builder()
-                    .with_instance_buffer(&self.instance_buffer)
+                    self.mesh_buffers = self.mesh_buffers
+                        .clone().with_culled_and_args_buffer(culled_buffer, indirect_args)
+                }
+                self.indirect_prev_params = params;
             }
         }
     }

--- a/renderer-gpu/src/mesh_buffers.rs
+++ b/renderer-gpu/src/mesh_buffers.rs
@@ -39,7 +39,7 @@ impl<I: MeshInstanceInput> MeshBuffers<I> {
     }
 
     pub fn with_instance_buffer(mut self, instance_buffer: &InstanceBuffer<I>) -> Self {
-        self.instance_buffer = instance_buffer.buffer.clone().map(Into::into);
+        self.instance_buffer = instance_buffer.buffer_with_id.clone();
         self
     }
 

--- a/renderer-gpu/src/text/text_renderer.rs
+++ b/renderer-gpu/src/text/text_renderer.rs
@@ -121,11 +121,11 @@ impl<I: MeshInstanceInput> TextRenderer<I> {
                 if v_buf.size() > 0 {
                     let (i_buf, i_buf_len) = &glyph_mesh.index_buf;
                     let instance_buffer = self.instance_buffer_map.get(glyph_id).unwrap();
-                    if let Some(instance_buffer) = instance_buffer.buffer.as_ref() {
+                    if let Some(instance_buffer) = instance_buffer.buffer_with_id.as_ref() {
                         render_pass.set_vertex_buffer(0, v_buf.slice(..));
                         render_pass.set_index_buffer(i_buf.slice(..), wgpu::IndexFormat::Uint32);
 
-                        render_pass.set_vertex_buffer(1, instance_buffer.slice(..));
+                        render_pass.set_vertex_buffer(1, instance_buffer.buffer().slice(..));
 
                         render_pass.draw_indexed(0..*i_buf_len as u32, 0, 0..list.len() as u32);
                     }

--- a/winit-run/src/main_gpu.rs
+++ b/winit-run/src/main_gpu.rs
@@ -15,7 +15,8 @@ use slint::{ComponentHandle, GraphicsAPI, PhysicalSize, RenderingState};
 use std::cmp::max;
 use std::str::FromStr;
 use std::sync::mpsc;
-use wgpu::TextureUsages;
+use std::time::{Duration, Instant};
+use wgpu::{Device, Instance, TextureUsages};
 use wgpu::{SurfaceColorSpace, SurfaceConfiguration};
 use renderer_gpu::render_config::RenderConfig;
 
@@ -38,6 +39,8 @@ pub fn prepare() {
         .select()
         .expect("Unable to create Slint backend with WGPU based renderer-gpu");
 }
+
+const GENERATE_INSTANCE_REPORT: bool = false;
 
 pub fn launch_internal(ui: &ShashlikUI) {
     let (slint_map_event_sender, slint_map_event_receiver) = mpsc::channel();
@@ -66,11 +69,13 @@ pub fn launch_internal(ui: &ShashlikUI) {
 
     let mut prev_pinch_scale: Option<Scale> = None;
     let mut prev_pan_state: Option<PanState> = None;
+    let mut last_report_time: Instant = Instant::now();
+    let mut device_instance: Option<(Device, Instance)> = None;
     ui.window()
         .set_rendering_notifier(move |state, graphics_api: &GraphicsAPI| {
             match state {
                 RenderingState::RenderingSetup => match graphics_api {
-                    GraphicsAPI::WGPU30 { device, queue, .. } => {
+                    GraphicsAPI::WGPU30 { instance, device, queue , .. } => {
                         let target_texture = device.create_texture(&wgpu::TextureDescriptor {
                             label: None,
                             size: wgpu::Extent3d {
@@ -161,6 +166,7 @@ pub fn launch_internal(ui: &ShashlikUI) {
                                 ShashlikMap::new(renderer, tiles_provider).await
                             }).unwrap();
 
+                        device_instance = Some((device.clone(), instance.clone()));
                         map.resize(texture_width as u32, texture_height as u32);
                         shashlik_map = Some(map);
                     }
@@ -170,6 +176,11 @@ pub fn launch_internal(ui: &ShashlikUI) {
                     if let (Some(shashlik_map), Some(app)) =
                         (shashlik_map.as_mut(), ui_weak.upgrade())
                     {
+                        if GENERATE_INSTANCE_REPORT && let Some((_, instance)) = &device_instance
+                            && last_report_time.elapsed() >= Duration::from_secs_f32(5.0) {
+                            last_report_time = Instant::now();
+                            println!("instanceReport: {:?}", instance.generate_report());
+                        }
                         while let Ok(event) = slint_map_event_receiver.try_recv() {
                             match event {
                                 SlintMapEvent::VerticalScroll(delta_y) => {


### PR DESCRIPTION
## Summary
1. Fixed #193. Indirect buffers were being created every frame with a new ID, which caused the BindGroup cache to create a new group every time. Now, InstanceBuffer uses BufferWithId, and the mesh checks if the indirect parameters have changed.
2. Added instance report logging for Linux/Mac platforms.