### PR TITLE
SSAO fixes and improvements

### DIFF
--- a/renderer-gpu/src/lib.rs
+++ b/renderer-gpu/src/lib.rs
@@ -194,7 +194,7 @@ impl GpuRenderer {
 
             self.layers
                 .shadow_map_layer
-                .set_texture(&self.global_context.texture_view_resources.get_or_unwrap(TextureViewKind::ShadowMapDepth), (0.0, 0.0), &self.global_context, &mut self.buffer_pool);
+                .set_texture(self.global_context.texture_view_resources.get(TextureViewKind::ShadowMapDepth), (0.0, 0.0), &self.global_context, &mut self.buffer_pool);
         }
 
         if self.render_config.ssao_enabled {
@@ -206,8 +206,12 @@ impl GpuRenderer {
 
             self.layers
                 .post_process_layer
-                .set_texture(self.global_context.texture_view_resources.get_or_unwrap(TextureViewKind::SSAO),
+                .set_texture(self.global_context.texture_view_resources.get(TextureViewKind::SSAO),
                              (0.0, 0.0), &self.global_context, &mut self.buffer_pool);
+
+            self.layers
+                .ground_layer
+                .set_texture(None, (0.0, 0.0), &self.global_context, &mut self.buffer_pool);
         }
 
         self.preview_textures.clear();
@@ -246,7 +250,7 @@ impl GpuRenderer {
         if let Some(texture_view) = self.preview_textures.get(&self.render_config.preview_type) {
             self.layers
                 .preview_mesh_layer
-                .set_texture(texture_view, (-100.0, -100.0), &self.global_context, &mut self.buffer_pool);
+                .set_texture(Some(texture_view), (-100.0, -100.0), &self.global_context, &mut self.buffer_pool);
         }
 
         let main_node = MainPassNode::new(&mut self.global_context,

--- a/renderer-gpu/src/mesh_layers/layers.rs
+++ b/renderer-gpu/src/mesh_layers/layers.rs
@@ -28,6 +28,7 @@ pub(crate) struct Layers {
     pub text_feature_layers: FeatureLayers<TextMeshLayer<ScreenShapeInstanceInput>>,
     pub preview_mesh_layer: OrthoMeshLayer<ScreenShapeInstanceInput>,
     pub post_process_layer: OrthoMeshLayer<ScreenShapeInstanceInput>,
+    // TODO This is a fake layer for Gbuf and SSAO. It somehow can be combined with shadow map in future
     pub ground_layer: OrthoMeshLayer<GeneralInstanceInput>,
 }
 

--- a/renderer-gpu/src/mesh_layers/layers.rs
+++ b/renderer-gpu/src/mesh_layers/layers.rs
@@ -28,6 +28,7 @@ pub(crate) struct Layers {
     pub text_feature_layers: FeatureLayers<TextMeshLayer<ScreenShapeInstanceInput>>,
     pub preview_mesh_layer: OrthoMeshLayer<ScreenShapeInstanceInput>,
     pub post_process_layer: OrthoMeshLayer<ScreenShapeInstanceInput>,
+    pub ground_layer: OrthoMeshLayer<GeneralInstanceInput>,
 }
 
 impl Layers {
@@ -63,6 +64,7 @@ impl Layers {
             text_feature_layers,
             preview_mesh_layer: OrthoMeshLayer::new(false, true, Into::into),
             post_process_layer: OrthoMeshLayer::new(true, false, Into::into),
+            ground_layer: OrthoMeshLayer::new(true, false, Into::into),
         }
     }
 
@@ -82,7 +84,7 @@ impl Layers {
         self.feature_layers.get_layer(tag)
     }
 
-    fn all_layers(&mut self) -> [&mut dyn BaseMeshLayer; 8] {
+    fn all_layers(&mut self) -> [&mut dyn BaseMeshLayer; 9] {
         [
             &mut self.shape_layer,
             &mut self.mesh_layer,
@@ -92,6 +94,7 @@ impl Layers {
             &mut self.text_feature_layers,
             &mut self.feature_layers,
             &mut self.preview_mesh_layer,
+            &mut self.ground_layer,
         ]
     }
 }

--- a/renderer-gpu/src/mesh_layers/ortho_mesh_layer.rs
+++ b/renderer-gpu/src/mesh_layers/ortho_mesh_layer.rs
@@ -40,12 +40,12 @@ impl<I: MeshInstanceInput> OrthoMeshLayer<I> {
     // FIXME Positioning should not be here
     pub fn set_texture(
         &mut self,
-        texture_view: &TextureView,
+        texture_view: Option<&TextureView>,
         offset: (f32, f32),
         global_context: &GlobalContext,
         buffer_pool: &mut BufferPool,
     ) {
-        self.texture_view = Some(texture_view.clone());
+        self.texture_view = texture_view.cloned();
         let screen_size = global_context.view_projection.screen_size;
 
         if screen_size.0 == 0.0 || screen_size.1 == 0.0 {
@@ -56,16 +56,15 @@ impl<I: MeshInstanceInput> OrthoMeshLayer<I> {
             return;
         }
 
-        let mesh_size;
+        let mut mesh_size = (screen_size.0 as f32, screen_size.1 as f32);
         if self.full_screen_mesh {
-            mesh_size = (screen_size.0 as f32, screen_size.1 as f32);
             self.mesh = Some(Mesh::quad(
                 global_context,
                 buffer_pool,
                 screen_size.0 as f32,
                 screen_size.1 as f32,
             ));
-        } else {
+        } else if let Some(texture_view) = self.texture_view.as_ref() {
             let texture_size = texture_view.texture().size();
             let aspect = texture_size.height as f32 / texture_size.width as f32;
             let width = screen_size.0 as f32 * 0.35;

--- a/renderer-gpu/src/pass_nodes/g_buffer_pass_node.rs
+++ b/renderer-gpu/src/pass_nodes/g_buffer_pass_node.rs
@@ -9,6 +9,7 @@ use wgpu::{CommandEncoder, TextureFormat, TextureUsages};
 
 pub(crate) struct GBufferPassNode {
     g_buf_pipeline: GBufPipeline,
+    g_buf_ground_pipeline: GBufPipeline,
 }
 
 impl GBufferPassNode {
@@ -52,7 +53,8 @@ impl GBufferPassNode {
             .texture_view_resources.insert(TextureViewKind::GBufDepth, non_msaa_depth_texture_view);
 
         Self {
-            g_buf_pipeline: GBufPipeline::new(global_context)
+            g_buf_pipeline: GBufPipeline::new(global_context, false),
+            g_buf_ground_pipeline: GBufPipeline::new(global_context, true)
         }
     }
 }
@@ -122,6 +124,7 @@ impl PassNode for GBufferPassNode {
 
         let mut render_pass = encoder.begin_render_pass(&descriptor);
 
+        layers.ground_layer.render(&mut render_pass, &mut self.g_buf_ground_pipeline, global_context);
         layers.mesh_layer.render(&mut render_pass, &mut self.g_buf_pipeline, global_context);
     }
 }

--- a/renderer-gpu/src/pass_nodes/g_buffer_pass_node.rs
+++ b/renderer-gpu/src/pass_nodes/g_buffer_pass_node.rs
@@ -23,7 +23,7 @@ impl GBufferPassNode {
                 sample_count: 1,
                 size: non_msaa_size,
                 usage: TextureUsages::RENDER_ATTACHMENT | TextureUsages::TEXTURE_BINDING,
-                format: TextureFormat::Rgba16Float,
+                format: TextureFormat::Rgba32Float,
             },
             global_context.device(),
         );

--- a/renderer-gpu/src/pass_nodes/ssao_pass_node.rs
+++ b/renderer-gpu/src/pass_nodes/ssao_pass_node.rs
@@ -249,7 +249,8 @@ impl SsaoPassNode {
                     0.0,
                 ).truncate().try_normalize();
 
-                if let Some(kernel) = kernel {
+                // filter kernels close to the surface to increase amount of effective kernels
+                if let Some(kernel) = kernel && kernel.z > 0.01 {
                     break kernel;
                 }
             };

--- a/renderer-gpu/src/pass_nodes/ssao_pass_node.rs
+++ b/renderer-gpu/src/pass_nodes/ssao_pass_node.rs
@@ -255,7 +255,7 @@ impl SsaoPassNode {
                 }
             };
             let t = i as f32 / ((N as f32) - 1.0);
-            (kernel * (0.1 + 0.9 * t * t)).extend(0.0)
+            (kernel * (0.1 + 0.9 * t * t)).extend(kernel.z)
         })
     }
 }

--- a/renderer-gpu/src/pass_nodes/ssao_pass_node.rs
+++ b/renderer-gpu/src/pass_nodes/ssao_pass_node.rs
@@ -25,10 +25,9 @@ impl SsaoPassNode {
         let device = global_context.device();
         let canvas = &global_context.canvas;
 
-        #[cfg(target_os = "macos")]
+        // SSAO is already expensive, let's try to make it better with one texture size first
+        // don't scale it down
         let ssao_size = (canvas.config().width, canvas.config().height);
-        #[cfg(not(target_os = "macos"))]
-        let mut ssao_size = (canvas.config().width / 2, canvas.config().height / 2);
 
         let ssao_texture = create_simple_texture(
             TextureData {
@@ -225,8 +224,14 @@ impl SsaoPassNode {
     fn generate_noise_texture_data() -> [Vec4; 16] {
         use core::array::from_fn;
         let mut rng = rng();
-        from_fn(|_| {
-            Self::generate_rnd_vec4(&mut rng)
+        let mut angles: [f32; 16] = from_fn(|i| {
+            (i as f32 + rng.random_range(0.0..1.0)) / 16.0 * std::f32::consts::TAU
+        });
+        for i in (1..16).rev() {
+            angles.swap(i, rng.random_range(0..=i));
+        }
+        from_fn(|i| {
+            Vec4::new(angles[i].cos(), angles[i].sin(), rng.random_range(-1.0..=1.0), 0.0)
         })
     }
 

--- a/renderer-gpu/src/pass_nodes/ssao_pass_node.rs
+++ b/renderer-gpu/src/pass_nodes/ssao_pass_node.rs
@@ -47,7 +47,7 @@ impl SsaoPassNode {
             },
             global_context.queue(),
             global_context.device(),
-            bytemuck::cast_slice(&Self::generate_noise_texture_data()),
+            bytemuck::cast_slice(&Self::generate_noise_texture_data::<16>()),
         );
 
         let kernel_texture = create_simple_texture_with_data(
@@ -59,7 +59,7 @@ impl SsaoPassNode {
             },
             global_context.queue(),
             global_context.device(),
-            bytemuck::cast_slice(&Self::generate_ssao_kernel_data()),
+            bytemuck::cast_slice(&Self::generate_ssao_kernel_data::<16>()),
         );
 
         let camera_ssao_bind_group_layout =
@@ -218,13 +218,13 @@ impl SsaoPassNode {
         }
     }
 
-    fn generate_noise_texture_data() -> [Vec4; 16] {
+    fn generate_noise_texture_data<const N: usize>() -> [Vec4; N] {
         use core::array::from_fn;
         let mut rng = rng();
-        let mut angles: [f32; 16] = from_fn(|i| {
-            (i as f32 + rng.random_range(0.0..1.0)) / 16.0 * std::f32::consts::TAU
+        let mut angles: [f32; N] = from_fn(|i| {
+            (i as f32 + rng.random_range(0.0..1.0)) / (N as f32) * std::f32::consts::TAU
         });
-        for i in (1..16).rev() {
+        for i in (1..N).rev() {
             angles.swap(i, rng.random_range(0..=i));
         }
         from_fn(|i| {
@@ -232,7 +232,7 @@ impl SsaoPassNode {
         })
     }
 
-    fn generate_ssao_kernel_data() -> [Vec4; 16] {
+    fn generate_ssao_kernel_data<const N: usize>() -> [Vec4; N] {
         use core::array::from_fn;
         let mut rng = rng();
         from_fn(|i| {
@@ -242,7 +242,7 @@ impl SsaoPassNode {
                 rng.random_range(0.0..=1.0),
                 0.0,
             ).truncate().normalize();
-            let t = i as f32 / (16.0 - 1.0) as f32;
+            let t = i as f32 / ((N as f32) - 1.0);
             (kernel * (0.1 + 0.9 * t * t)).extend(0.0)
         })
     }

--- a/renderer-gpu/src/pass_nodes/ssao_pass_node.rs
+++ b/renderer-gpu/src/pass_nodes/ssao_pass_node.rs
@@ -240,12 +240,19 @@ impl SsaoPassNode {
         use core::array::from_fn;
         let mut rng = rng();
         from_fn(|i| {
-            let kernel = Vec4::new(
-                rng.random_range(-1.0..=1.0),
-                rng.random_range(-1.0..=1.0),
-                rng.random_range(0.0..=1.0),
-                0.0,
-            ).truncate().normalize();
+            // loop prevents non-finite vector after normalization
+            let kernel = loop {
+                let kernel = Vec4::new(
+                    rng.random_range(-1.0..=1.0),
+                    rng.random_range(-1.0..=1.0),
+                    rng.random_range(0.0..=1.0),
+                    0.0,
+                ).truncate().try_normalize();
+
+                if let Some(kernel) = kernel {
+                    break kernel;
+                }
+            };
             let t = i as f32 / ((N as f32) - 1.0);
             (kernel * (0.1 + 0.9 * t * t)).extend(0.0)
         })

--- a/renderer-gpu/src/pass_nodes/ssao_pass_node.rs
+++ b/renderer-gpu/src/pass_nodes/ssao_pass_node.rs
@@ -244,7 +244,7 @@ impl SsaoPassNode {
         let mut rng = rng();
         from_fn(|_| {
             let mut v = Self::generate_rnd_vec4_2(&mut rng).normalize();
-            v *= rng.random_range(0.0..=1.0);
+            // v *= rng.random_range(0.0..=1.0);
             v
         })
     }

--- a/renderer-gpu/src/pass_nodes/ssao_pass_node.rs
+++ b/renderer-gpu/src/pass_nodes/ssao_pass_node.rs
@@ -20,6 +20,11 @@ pub(crate) struct SsaoPassNode {
 }
 
 impl SsaoPassNode {
+    // TODO Sync with ones in shader, someday
+    const NOISE_SIZE: usize = 16;
+
+    const KERNEL_SIZE: usize = 16;
+
     pub fn new(global_context: &mut GlobalContext) -> Self {
         let device = global_context.device();
         let canvas = &global_context.canvas;
@@ -38,28 +43,32 @@ impl SsaoPassNode {
             device,
         );
 
+        const {
+            assert!(Self::NOISE_SIZE.isqrt().pow(2) == Self::NOISE_SIZE);
+        };
+        let size = Self::NOISE_SIZE.isqrt() as u32;
         let noise_texture = create_simple_texture_with_data(
             TextureData {
                 sample_count: 1,
-                size: (4, 4),
+                size: (size, size),
                 usage: TextureUsages::TEXTURE_BINDING,
                 format: TextureFormat::Rgba32Float,
             },
             global_context.queue(),
             global_context.device(),
-            bytemuck::cast_slice(&Self::generate_noise_texture_data::<16>()),
+            bytemuck::cast_slice(&Self::generate_noise_texture_data::<{Self::NOISE_SIZE}>()),
         );
 
         let kernel_texture = create_simple_texture_with_data(
             TextureData {
                 sample_count: 1,
-                size: (16, 1),
+                size: (Self::KERNEL_SIZE as u32, 1),
                 usage: TextureUsages::TEXTURE_BINDING,
                 format: TextureFormat::Rgba32Float,
             },
             global_context.queue(),
             global_context.device(),
-            bytemuck::cast_slice(&Self::generate_ssao_kernel_data::<16>()),
+            bytemuck::cast_slice(&Self::generate_ssao_kernel_data::<{Self::KERNEL_SIZE}>()),
         );
 
         let camera_ssao_bind_group_layout =
@@ -221,14 +230,9 @@ impl SsaoPassNode {
     fn generate_noise_texture_data<const N: usize>() -> [Vec4; N] {
         use core::array::from_fn;
         let mut rng = rng();
-        let mut angles: [f32; N] = from_fn(|i| {
-            (i as f32 + rng.random_range(0.0..1.0)) / (N as f32) * std::f32::consts::TAU
-        });
-        for i in (1..N).rev() {
-            angles.swap(i, rng.random_range(0..=i));
-        }
         from_fn(|i| {
-            Vec4::new(angles[i].cos(), angles[i].sin(), 0.0, 0.0).normalize()
+            let angle = (i as f32 + rng.random_range(0.0..1.0)) / (N as f32) * std::f32::consts::TAU;
+            Vec4::new(angle.cos(), angle.sin(), 0.0, 0.0)
         })
     }
 

--- a/renderer-gpu/src/pass_nodes/ssao_pass_node.rs
+++ b/renderer-gpu/src/pass_nodes/ssao_pass_node.rs
@@ -44,7 +44,7 @@ impl SsaoPassNode {
         let noise_texture = create_simple_texture_with_data(
             TextureData {
                 sample_count: 1,
-                size: (64, 64),
+                size: (4, 4),
                 usage: TextureUsages::TEXTURE_BINDING,
                 format: TextureFormat::Rgba32Float,
             },
@@ -63,7 +63,7 @@ impl SsaoPassNode {
             },
             global_context.queue(),
             global_context.device(),
-            bytemuck::cast_slice(&Self::generate_ssao_kerner_data()),
+            bytemuck::cast_slice(&Self::generate_ssao_kernel_data()),
         );
 
         let ssao_bind_group_layout =
@@ -222,15 +222,11 @@ impl SsaoPassNode {
         }
     }
 
-    fn generate_noise_texture_data() -> [[Vec4; 3]; 4096] {
+    fn generate_noise_texture_data() -> [Vec4; 16] {
         use core::array::from_fn;
         let mut rng = rng();
         from_fn(|_| {
-            [
-                Self::generate_rnd_vec4(&mut rng),
-                Self::generate_rnd_vec4(&mut rng),
-                Self::generate_rnd_vec4(&mut rng),
-            ]
+            Self::generate_rnd_vec4(&mut rng)
         })
     }
 
@@ -243,15 +239,13 @@ impl SsaoPassNode {
         )
     }
 
-    fn generate_ssao_kerner_data() -> [[Vec4; 3]; 16] {
+    fn generate_ssao_kernel_data() -> [Vec4; 16] {
         use core::array::from_fn;
         let mut rng = rng();
         from_fn(|_| {
-            [
-                Self::generate_rnd_vec4_2(&mut rng),
-                Self::generate_rnd_vec4_2(&mut rng),
-                Self::generate_rnd_vec4_2(&mut rng),
-            ]
+            let mut v = Self::generate_rnd_vec4_2(&mut rng).normalize();
+            v *= rng.random_range(0.0..=1.0);
+            v
         })
     }
 

--- a/renderer-gpu/src/pass_nodes/ssao_pass_node.rs
+++ b/renderer-gpu/src/pass_nodes/ssao_pass_node.rs
@@ -1,9 +1,9 @@
 use crate::global_context::GlobalContext;
 use crate::mesh_layers::layers::Layers;
 use crate::pass_nodes::PassNode;
-use crate::textures::{create_simple_texture, create_simple_texture_with_data, TextureData};
+use crate::texture_view_resources::TextureViewKind;
+use crate::textures::{TextureData, create_simple_texture, create_simple_texture_with_data};
 use glam::Vec4;
-use rand::prelude::ThreadRng;
 use rand::{RngExt, rng};
 use std::borrow::Cow;
 use wesl::include_wesl;
@@ -12,7 +12,6 @@ use wgpu::{
     ImageSubresourceRange, ShaderModuleDescriptor, ShaderSource, StorageTextureAccess,
     TextureFormat, TextureUsages, TextureViewDimension,
 };
-use crate::texture_view_resources::TextureViewKind;
 
 pub(crate) struct SsaoPassNode {
     ssao_bind_group: BindGroup,
@@ -39,7 +38,6 @@ impl SsaoPassNode {
             device,
         );
 
-        // TODO Remove the third Vec4 value from the texture data generators.
         let noise_texture = create_simple_texture_with_data(
             TextureData {
                 sample_count: 1,
@@ -52,7 +50,6 @@ impl SsaoPassNode {
             bytemuck::cast_slice(&Self::generate_noise_texture_data()),
         );
 
-        // TODO Remove the third Vec4 value from the texture data generators.
         let kernel_texture = create_simple_texture_with_data(
             TextureData {
                 sample_count: 1,
@@ -64,6 +61,33 @@ impl SsaoPassNode {
             global_context.device(),
             bytemuck::cast_slice(&Self::generate_ssao_kernel_data()),
         );
+
+        let camera_ssao_bind_group_layout =
+            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                entries: &[wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::COMPUTE,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                }],
+                label: Some("camera_ssao_pipeline_group_layout"),
+            });
+
+        let camera_ssao_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            layout: &camera_ssao_bind_group_layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: global_context
+                    .view_projection
+                    .uniform_buffer
+                    .as_entire_binding(),
+            }],
+            label: Some("ssao_camera_pipeline_bind_group"),
+        });
 
         let ssao_bind_group_layout =
             device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
@@ -121,34 +145,7 @@ impl SsaoPassNode {
                 ],
                 label: Some("ssao_bind_group_layout"),
             });
-
-        let camera_ssao_bind_group_layout =
-            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-                entries: &[wgpu::BindGroupLayoutEntry {
-                    binding: 0,
-                    visibility: wgpu::ShaderStages::COMPUTE,
-                    ty: wgpu::BindingType::Buffer {
-                        ty: wgpu::BufferBindingType::Uniform,
-                        has_dynamic_offset: false,
-                        min_binding_size: None,
-                    },
-                    count: None,
-                }],
-                label: Some("camera_ssao_pipeline_group_layout"),
-            });
-
-        let camera_ssao_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
-            layout: &camera_ssao_bind_group_layout,
-            entries: &[wgpu::BindGroupEntry {
-                binding: 0,
-                resource: global_context
-                    .view_projection
-                    .uniform_buffer
-                    .as_entire_binding(),
-            }],
-            label: Some("ssao_camera_pipeline_bind_group"),
-        });
-
+        
         let ssao_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
             layout: &ssao_bind_group_layout,
             entries: &[
@@ -190,8 +187,8 @@ impl SsaoPassNode {
                 .create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
                     label: Some("SSAO Pipeline Layout"),
                     bind_group_layouts: &[
-                        Some(&ssao_bind_group_layout),
                         Some(&camera_ssao_bind_group_layout),
+                        Some(&ssao_bind_group_layout),
                     ],
                     ..Default::default()
                 });
@@ -235,32 +232,17 @@ impl SsaoPassNode {
         })
     }
 
-    fn generate_rnd_vec4(rng: &mut ThreadRng) -> Vec4 {
-        Vec4::new(
-            rng.random_range(-1.0..=1.0),
-            rng.random_range(-1.0..=1.0),
-            rng.random_range(-1.0..=1.0),
-            0.0,
-        )
-    }
-
     fn generate_ssao_kernel_data() -> [Vec4; 16] {
         use core::array::from_fn;
         let mut rng = rng();
         from_fn(|_| {
-            let mut v = Self::generate_rnd_vec4_2(&mut rng).normalize();
-            // v *= rng.random_range(0.0..=1.0);
-            v
+            Vec4::new(
+                rng.random_range(-1.0..=1.0),
+                rng.random_range(-1.0..=1.0),
+                rng.random_range(0.0..=1.0),
+                0.0,
+            )
         })
-    }
-
-    fn generate_rnd_vec4_2(rng: &mut ThreadRng) -> Vec4 {
-        Vec4::new(
-            rng.random_range(-1.0..=1.0),
-            rng.random_range(-1.0..=1.0),
-            rng.random_range(0.0..=1.0),
-            0.0,
-        )
     }
 }
 
@@ -279,8 +261,8 @@ impl PassNode for SsaoPassNode {
                 timestamp_writes: None,
             });
             compute_pass.set_pipeline(&self.ssao_compute_pipeline);
-            compute_pass.set_bind_group(0, &self.ssao_bind_group, &[]);
-            compute_pass.set_bind_group(1, &self.camera_ssao_bind_group, &[]);
+            compute_pass.set_bind_group(0, &self.camera_ssao_bind_group, &[]);
+            compute_pass.set_bind_group(1, &self.ssao_bind_group, &[]);
             let wg_x = (ssao_texture.size().width as f32 / 8.0).ceil() as u32;
             let wg_y = (ssao_texture.size().height as f32 / 8.0).ceil() as u32;
             compute_pass.dispatch_workgroups(wg_x, wg_y, 1);

--- a/renderer-gpu/src/pass_nodes/ssao_pass_node.rs
+++ b/renderer-gpu/src/pass_nodes/ssao_pass_node.rs
@@ -145,7 +145,7 @@ impl SsaoPassNode {
                 ],
                 label: Some("ssao_bind_group_layout"),
             });
-        
+
         let ssao_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
             layout: &ssao_bind_group_layout,
             entries: &[
@@ -228,20 +228,22 @@ impl SsaoPassNode {
             angles.swap(i, rng.random_range(0..=i));
         }
         from_fn(|i| {
-            Vec4::new(angles[i].cos(), angles[i].sin(), rng.random_range(-1.0..=1.0), 0.0)
+            Vec4::new(angles[i].cos(), angles[i].sin(), 0.0, 0.0).normalize()
         })
     }
 
     fn generate_ssao_kernel_data() -> [Vec4; 16] {
         use core::array::from_fn;
         let mut rng = rng();
-        from_fn(|_| {
-            Vec4::new(
+        from_fn(|i| {
+            let kernel = Vec4::new(
                 rng.random_range(-1.0..=1.0),
                 rng.random_range(-1.0..=1.0),
                 rng.random_range(0.0..=1.0),
                 0.0,
-            )
+            ).truncate().normalize();
+            let t = i as f32 / (16.0 - 1.0) as f32;
+            (kernel * (0.1 + 0.9 * t * t)).extend(0.0)
         })
     }
 }

--- a/renderer-gpu/src/pipelines/g_buf_pipeline.rs
+++ b/renderer-gpu/src/pipelines/g_buf_pipeline.rs
@@ -4,7 +4,7 @@ use crate::pipelines::mesh_pipeline::MeshPipeline;
 use crate::vertex_attrs::{GeneralInstanceInput, MeshVertexWithUV, VertexAttrib};
 use std::borrow::Cow;
 use wesl::include_wesl;
-use wgpu::TextureFormat::Rgba16Float;
+use wgpu::TextureFormat::{Rgba16Float, Rgba32Float};
 use wgpu::{RenderPass, ShaderModuleDescriptor, ShaderSource, TextureFormat};
 
 pub struct GBufPipeline {
@@ -34,7 +34,7 @@ impl GBufPipeline {
         fragment.module = g_buf_frag_shader_module;
         fragment.targets = vec![
             Some(wgpu::ColorTargetState {
-                format: Rgba16Float,
+                format: Rgba32Float,
                 blend: None,
                 write_mask: wgpu::ColorWrites::ALL,
             }),

--- a/renderer-gpu/src/pipelines/g_buf_pipeline.rs
+++ b/renderer-gpu/src/pipelines/g_buf_pipeline.rs
@@ -1,7 +1,7 @@
 use crate::global_context::GlobalContext;
-use crate::pipelines::mesh_pipeline::MeshPipeline;
 use crate::pipelines::RenderPipeline;
-use crate::vertex_attrs::GeneralInstanceInput;
+use crate::pipelines::mesh_pipeline::MeshPipeline;
+use crate::vertex_attrs::{GeneralInstanceInput, MeshVertexWithUV, VertexAttrib};
 use std::borrow::Cow;
 use wesl::include_wesl;
 use wgpu::TextureFormat::Rgba16Float;
@@ -13,7 +13,7 @@ pub struct GBufPipeline {
 }
 
 impl GBufPipeline {
-    pub fn new(global_context: &GlobalContext) -> Self {
+    pub fn new(global_context: &GlobalContext, with_vertex: bool) -> Self {
         let mesh_pipeline = MeshPipeline::new(global_context, false, false, false);
         let mut root_descriptor = mesh_pipeline.prepare(global_context);
 
@@ -25,6 +25,11 @@ impl GBufPipeline {
                     source: ShaderSource::Wgsl(Cow::from(include_wesl!("g_buf_frag_shader"))),
                 });
         root_descriptor.label = Some("g_buffer_pipeline");
+        if with_vertex {
+            root_descriptor.vertex.module = g_buf_frag_shader_module.to_owned();
+            root_descriptor.vertex.buffers = vec![MeshVertexWithUV::desc(), GeneralInstanceInput::desc()];
+            root_descriptor.primitive.cull_mode = None;
+        }
         let fragment = root_descriptor.fragment.as_mut().unwrap();
         fragment.module = g_buf_frag_shader_module;
         fragment.targets = vec![
@@ -39,7 +44,6 @@ impl GBufPipeline {
                 write_mask: wgpu::ColorWrites::ALL,
             }),
         ];
-        fragment.entry_point = Some("fs_main_g_buf");
         root_descriptor.multisample.count = 1;
         // render pass for g buffer uses Depth24Plus but original descriptor Depth24PlusStencil8
         root_descriptor.depth_stencil.as_mut().unwrap().format = TextureFormat::Depth24Plus;

--- a/renderer-gpu/src/shaders/g_buf_frag_shader.wgsl
+++ b/renderer-gpu/src/shaders/g_buf_frag_shader.wgsl
@@ -1,12 +1,37 @@
-import super::mesh_shader_common::{VertexOutput};
+import super::mesh_shader_common::{VertexOutput, InstanceInput};
+import super::common::CameraUniform;
+import super::common::frag_pos_from_ray;
 
 struct GBuffer {
     @location(0) positions: vec4<f32>,
     @location(1) normal: vec4<f32>,
 }
 
+struct VertexInput {
+    @location(0) position: vec2<f32>,
+    @location(1) color: vec4<f32>,
+    @location(2) uv: vec2<f32>,
+}
+
+@group(0) @binding(0)
+var<uniform> camera: CameraUniform;
+
+@vertex
+fn vs_main(
+    model: VertexInput,
+    pos: InstanceInput
+) -> VertexOutput {
+    let clip_pos2d = model.uv * 2.0 - 1.0;
+    let final_world_pos = (vec4<f32>(frag_pos_from_ray(camera, clip_pos2d), 1.0));
+
+    var out: VertexOutput;
+    out.view_position = (camera.view * vec4f(final_world_pos.xyz, 1.0)).xyz;
+    out.view_normal = (camera.view_tr_inv * vec4f(0.0, 0.0, -1.0, 1.0)).xyz;
+    out.clip_position = camera.view_proj * final_world_pos;
+    return out;
+}
+
 @fragment
-fn fs_main_g_buf(in: VertexOutput) -> GBuffer {
-    // TODO use view matrix to calc z in VS instead of in.clip_position.z?
+fn fs_main(in: VertexOutput) -> GBuffer {
     return GBuffer(vec4(in.view_position.xyz, 1.0), vec4(in.view_normal.xyz, 1.0));
 }

--- a/renderer-gpu/src/shaders/mesh_shader.wgsl
+++ b/renderer-gpu/src/shaders/mesh_shader.wgsl
@@ -27,7 +27,6 @@ fn vs_main(
     var modelnormal = model.normal;
     // TODO
     modelnormal.z = -abs(modelnormal.z);
-    out.world_position = modelpos;
     out.world_normal = -modelnormal;
 
     out.view_position = (camera.view * vec4f(modelpos, 1.0)).xyz;

--- a/renderer-gpu/src/shaders/mesh_shader_common.wgsl
+++ b/renderer-gpu/src/shaders/mesh_shader_common.wgsl
@@ -19,8 +19,7 @@ struct VertexOutput {
     @location(1) view_normal: vec3<f32>,
     @location(2) view_position: vec3<f32>,
     @location(3) world_normal: vec3<f32>,
-    @location(4) world_position: vec3<f32>,
-    @location(5) pos_from_light: vec4<f32>,
-    @location(6) color_alpha: f32,
-    @location(7) height: f32,
+    @location(4) pos_from_light: vec4<f32>,
+    @location(5) color_alpha: f32,
+    @location(6) height: f32,
 }

--- a/renderer-gpu/src/shaders/screen_mesh_shader.wgsl
+++ b/renderer-gpu/src/shaders/screen_mesh_shader.wgsl
@@ -129,17 +129,19 @@ const weights = array<f32, 9>(
 @fragment
 fn fs_main_tex_storage(in: VertexOutput) -> @location(0) vec4<f32> {
     var result = 0.0;
-    let texelSize = 1.0 / vec2f(textureDimensions(t_diffuse));
+    let dims = vec2f(textureDimensions(t_diffuse));
+    let texelSize = 1.0 / dims;
+    let base = (floor(in.uv * dims) + 0.5) * texelSize;
 
-    for (var y = -2; y <= 2; y += 2) {
+    for (var y = -1; y <= 1; y += 2) {
         for (var x = -1; x <= 1; x += 2) {
-            let offset = in.uv + vec2f(f32(x), f32(y)) * texelSize * 0.5;
+            let offset = base + (vec2f(f32(x), f32(y)) - 0.5) * texelSize;
             result += textureSample(t_diffuse, s_diffuse, offset).r;
         }
     }
     result = result / 4.0;
 
-    return vec4f(0.0, 0.0, 0.0, result * max(0.0, 1.0 - camera.scale * 2.0));
+    return vec4f(0.0, 0.0, 0.0, result * max(0.0, 1.0 - camera.scale * 1.0));
 }
 
 @fragment

--- a/renderer-gpu/src/shaders/screen_mesh_shader.wgsl
+++ b/renderer-gpu/src/shaders/screen_mesh_shader.wgsl
@@ -120,12 +120,6 @@ fn fs_main_textured(in: VertexOutput) -> @location(0) vec4<f32> {
     }
 }
 
-const weights = array<f32, 9>(
-        1.0, 2.0, 1.0,
-        2.0, 4.0, 2.0,
-        1.0, 2.0, 1.0
-    );
-
 @fragment
 fn fs_main_tex_storage(in: VertexOutput) -> @location(0) vec4<f32> {
     let a_koef = max(0.0, 1.0 - camera.scale * 0.5);

--- a/renderer-gpu/src/shaders/screen_mesh_shader.wgsl
+++ b/renderer-gpu/src/shaders/screen_mesh_shader.wgsl
@@ -131,16 +131,13 @@ fn fs_main_tex_storage(in: VertexOutput) -> @location(0) vec4<f32> {
     var result = 0.0;
     let texelSize = 1.0 / vec2f(textureDimensions(t_diffuse));
 
-    var index = 0;
-
-    for (var y = -1; y <= 1; y++) {
-        for (var x = -1; x <= 1; x++) {
-            let offset = in.uv + vec2f(f32(x), f32(y)) * texelSize;
-            result += textureSample(t_diffuse, s_diffuse, offset).r * weights[index];
-            index++;
+    for (var y = -2; y <= 2; y += 2) {
+        for (var x = -1; x <= 1; x += 2) {
+            let offset = in.uv + vec2f(f32(x), f32(y)) * texelSize * 0.5;
+            result += textureSample(t_diffuse, s_diffuse, offset).r;
         }
     }
-    result = result / 16.0;
+    result = result / 4.0;
 
     return vec4f(0.0, 0.0, 0.0, result * max(0.0, 1.0 - camera.scale * 2.0));
 }

--- a/renderer-gpu/src/shaders/screen_mesh_shader.wgsl
+++ b/renderer-gpu/src/shaders/screen_mesh_shader.wgsl
@@ -128,6 +128,11 @@ const weights = array<f32, 9>(
 
 @fragment
 fn fs_main_tex_storage(in: VertexOutput) -> @location(0) vec4<f32> {
+    let a_koef = max(0.0, 1.0 - camera.scale * 0.5);
+    if a_koef <= 0.0 {
+        return vec4f(0.0, 0.0, 0.0, 0.0);
+    }
+
     var result = 0.0;
     let dims = vec2f(textureDimensions(t_diffuse));
     let texelSize = 1.0 / dims;
@@ -141,7 +146,7 @@ fn fs_main_tex_storage(in: VertexOutput) -> @location(0) vec4<f32> {
     }
     result = result / 4.0;
 
-    return vec4f(0.0, 0.0, 0.0, result * max(0.0, 1.0 - camera.scale * 1.0));
+    return vec4f(0.0, 0.0, 0.0, result * a_koef);
 }
 
 @fragment

--- a/renderer-gpu/src/shaders/ssao.wgsl
+++ b/renderer-gpu/src/shaders/ssao.wgsl
@@ -1,5 +1,4 @@
 import super::common::CameraUniform;
-import super::common::frag_pos_from_ray;
 
 @group(0) @binding(0)
 var<uniform> camera: CameraUniform;
@@ -34,21 +33,9 @@ const noise_size: u32 = 4;
 fn compute_ssao(pixel_coord: vec2<u32>, ssao_size: vec2f, screen_size: vec2f) {
     let pixel_mul = u32(round(screen_size.x / ssao_size.x));
     let loadedNormal = textureLoad(normals, pixel_mul * pixel_coord, 0).xyz;
-    if(loadedNormal.y > 0.0) {
-        return;
-    }
-    var normal = loadedNormal;
 
-    var fragPos = vec3f(0.0, 0.0, 0.0);
-    if(loadedNormal.x == 0.0 && loadedNormal.y == 0.0 && loadedNormal.z == 0.0) {
-        let uv_coord = (vec2f(pixel_mul * pixel_coord.xy) * camera.inv_screen_size) * 2.0 - 1.0;
-        fragPos = frag_pos_from_ray(camera, uv_coord);
-        fragPos = (camera.view * vec4f(fragPos, 1.0)).xyz;
-        normal = normalize((camera.view_tr_inv * vec4f(0.0, 0.0, 1.0, 1.0)).xyz);
-    } else {
-        normal = -normalize(loadedNormal);
-        fragPos = textureLoad(positions, pixel_mul * pixel_coord, 0).xyz;
-    }
+    let normal = -normalize(loadedNormal);
+    let fragPos = textureLoad(positions, pixel_mul * pixel_coord, 0).xyz;
 
     let noise_sample_coords = pixel_coord % vec2u(noise_size, noise_size);
     let noise_vec = textureLoad(noise, noise_sample_coords, 0).rgb;
@@ -61,7 +48,9 @@ fn compute_ssao(pixel_coord: vec2<u32>, ssao_size: vec2f, screen_size: vec2f) {
     for (var i = 0; i < samples; i++) {
         var kernel = textureLoad(kernel, vec2(i, 0), 0).rgb;
         let samplePos = fragPos + (TBN * kernel) * radius;
-
+        if(abs(samplePos.z - fragPos.z) <= 0.0001) {
+            continue;
+        }
         let offset = camera.proj * vec4f(samplePos, 1.0);
         let ndcPos = offset.xy / offset.w;
         let uv = ndcPos * vec2f(0.5, -0.5) + vec2f(0.5);
@@ -71,7 +60,8 @@ fn compute_ssao(pixel_coord: vec2<u32>, ssao_size: vec2f, screen_size: vec2f) {
             continue;
         }
         let sampleDepth = textureLoad(positions, screenCoord, 0).z;
-        let rangeCheck = smoothstep(0.0, 1.0, (radius) / abs(fragPos.z - sampleDepth));
+        let depth_diff = abs(fragPos.z - sampleDepth);
+        let rangeCheck = smoothstep(0.0, 1.0, radius / depth_diff);
 
         valid += 1.0;
         occlusion += select(0.0, 1.0, sampleDepth > samplePos.z + 0.03) * rangeCheck;

--- a/renderer-gpu/src/shaders/ssao.wgsl
+++ b/renderer-gpu/src/shaders/ssao.wgsl
@@ -51,6 +51,7 @@ fn compute_ssao(pixel_coord: vec2<u32>, ssao_size: vec2f, screen_size: vec2f) {
 
         let dot_bias = max(dot(normal, normalize(sample_vector)), 0.0);
         // fast exit if sample_vector is orthogonal to normal
+        // TODO we can prepare kernel to prevent wasted samples
         if(dot_bias == 0.0) {
             continue;
         }

--- a/renderer-gpu/src/shaders/ssao.wgsl
+++ b/renderer-gpu/src/shaders/ssao.wgsl
@@ -27,7 +27,7 @@ fn compute_main(@builtin(global_invocation_id) id: vec3<u32>) {
     compute_ssao(pixel_coord, vec2f(ssao_size), screen_size);
 }
 
-const radius: f32 = 0.5;
+const radius: f32 = 0.35;
 
 const samples: i32 = 16;
 
@@ -60,6 +60,7 @@ fn compute_ssao(pixel_coord: vec2<u32>, ssao_size: vec2f, screen_size: vec2f) {
     let TBN = mat3x3(tangent, bitangent, normal);
 
     var occlusion = 0.0;
+    var valid = 0.0;
     for (var i = 0; i < samples; i++) {
         var kl = textureLoad(kernel, vec2(i, 0), 0).rgb;
         let dist_scale = f32(i) / f32(samples);
@@ -76,14 +77,13 @@ fn compute_ssao(pixel_coord: vec2<u32>, ssao_size: vec2f, screen_size: vec2f) {
         let ndcPos = offset.xy / offset.w;
         let uv = ndcPos * vec2f(0.5, -0.5) + vec2f(0.5);
         let screenCoord = vec2i(uv * screen_size);
-
         let sampleDepth = textureLoad(positions, screenCoord, 0).z;
-
         let rangeCheck = smoothstep(0.0, 1.0, (radius) / abs(fragPos.z - sampleDepth));
 
+        valid += 1.0;
         occlusion += select(0.0, 1.0, sampleDepth > samplePos.z + 0.025) * rangeCheck;
     }
 
-    occlusion = occlusion / f32(samples);
+    occlusion = occlusion / valid;
     textureStore(ssao_texture, pixel_coord, vec4f(occlusion, 0.0, 0.0, 0.0));
 }

--- a/renderer-gpu/src/shaders/ssao.wgsl
+++ b/renderer-gpu/src/shaders/ssao.wgsl
@@ -29,7 +29,7 @@ const radius: f32 = 0.5;
 const samples: i32 = 16;
 
 const noise_size: u32 = 4;
-const noise_vec = vec2u(noise_size, noise_size);
+const noise_tile = vec2u(noise_size, noise_size);
 
 fn compute_ssao(pixel_coord: vec2<u32>, ssao_size: vec2f, screen_size: vec2f) {
     let pixel_mul = u32(round(screen_size.x / ssao_size.x));
@@ -38,48 +38,51 @@ fn compute_ssao(pixel_coord: vec2<u32>, ssao_size: vec2f, screen_size: vec2f) {
     let normal = -normalize(loaded_normal);
     let frag_pos = textureLoad(positions, pixel_mul * pixel_coord, 0).xyz;
 
-    let noise_sample_coords = pixel_coord % noise_vec;
+    let noise_sample_coords = pixel_coord % noise_tile;
     let noise_vec = textureLoad(noise, noise_sample_coords, 0).rgb;
 
     let normal_dot_p = dot(noise_vec, normal);
     var TBN: mat3x3<f32>;
     // TODO So far we use Duff's method as a fallback. Further, we could try to combine Duff's with random vector to remove branching.
-    if (normal_dot_p > 0.999) {
+    if (abs(normal_dot_p) > 0.999) {
         TBN = duff_onb(normal);
     } else {
         TBN = gram_schmidt_onb(normal, noise_vec, normal_dot_p);
     }
 
     var occlusion = 0.0;
-    var valid = 0.0;
+    var weight_sum = 0.0;
     for (var i = 0; i < samples; i++) {
-        var kernel = textureLoad(kernel, vec2(i, 0), 0).rgb;
-        let sample_vector = TBN * kernel;
+        var kernel_vec = textureLoad(kernel, vec2(i, 0), 0);
+        let sample_vector = TBN * kernel_vec.xyz;
 
-        let dot_bias = max(dot(normal, normalize(sample_vector)), 0.0);
         let sample_pos = frag_pos + sample_vector * radius;
 
         let offset = camera.proj * vec4f(sample_pos, 1.0);
         let ndcPos = offset.xy / offset.w;
         let uv = ndcPos * vec2f(0.5, -0.5) + vec2f(0.5);
+        if (any(uv < vec2f(0.0)) || any(uv >= vec2f(1.0))) {
+            continue;
+        }
         let screen_coord = vec2i(uv * screen_size);
         let center_coord = vec2i(pixel_mul * pixel_coord);
         if (all(screen_coord == center_coord)) {
             continue;
         }
+        let dot_bias = kernel_vec.w;
         let slope_bias: f32 = max(0.05 * (1.0 - dot_bias), 0.005);
 
         let sample_depth = textureLoad(positions, screen_coord, 0).z;
         let depth_diff = abs(frag_pos.z - sample_depth) + 0.001;
         let range_check = smoothstep(0.0, 1.0, radius / depth_diff);
 
-        valid += 1.0;
+        weight_sum += dot_bias;
         occlusion += select(0.0, 1.0, sample_depth >= sample_pos.z + slope_bias) * range_check * dot_bias;
     }
 
-    // valid potentially can be 0.0
-    occlusion = select(0.0, occlusion / valid, valid > 0.0);
-    textureStore(ssao_texture, pixel_coord, vec4f(occlusion, 0.0, 0.0, 0.0));
+    // weight_sum potentially can be 0.0
+    occlusion = select(0.0, occlusion / weight_sum, weight_sum > 0.0);
+    textureStore(ssao_texture, pixel_coord, vec4f(occlusion * 0.5, 0.0, 0.0, 0.0));
 }
 
 fn gram_schmidt_onb(normal: vec3<f32>, noise_vec: vec3<f32>, dot_p: f32) -> mat3x3<f32> {

--- a/renderer-gpu/src/shaders/ssao.wgsl
+++ b/renderer-gpu/src/shaders/ssao.wgsl
@@ -32,10 +32,10 @@ const noise_size: u32 = 4;
 
 fn compute_ssao(pixel_coord: vec2<u32>, ssao_size: vec2f, screen_size: vec2f) {
     let pixel_mul = u32(round(screen_size.x / ssao_size.x));
-    let loadedNormal = textureLoad(normals, pixel_mul * pixel_coord, 0).xyz;
+    let loaded_normal = textureLoad(normals, pixel_mul * pixel_coord, 0).xyz;
 
-    let normal = -normalize(loadedNormal);
-    let fragPos = textureLoad(positions, pixel_mul * pixel_coord, 0).xyz;
+    let normal = -normalize(loaded_normal);
+    let frag_pos = textureLoad(positions, pixel_mul * pixel_coord, 0).xyz;
 
     let noise_sample_coords = pixel_coord % vec2u(noise_size, noise_size);
     let noise_vec = textureLoad(noise, noise_sample_coords, 0).rgb;
@@ -47,24 +47,29 @@ fn compute_ssao(pixel_coord: vec2<u32>, ssao_size: vec2f, screen_size: vec2f) {
     var valid = 0.0;
     for (var i = 0; i < samples; i++) {
         var kernel = textureLoad(kernel, vec2(i, 0), 0).rgb;
-        let samplePos = fragPos + (TBN * kernel) * radius;
-        if(abs(samplePos.z - fragPos.z) <= 0.0001) {
+        let sample_vector = TBN * kernel;
+
+        let dot_bias = max(dot(normal, normalize(sample_vector)), 0.0);
+        // fast exit if sample_vector is orthogonal to normal
+        if(dot_bias == 0.0) {
             continue;
         }
-        let offset = camera.proj * vec4f(samplePos, 1.0);
+        let sample_pos = frag_pos + sample_vector * radius;
+
+        let offset = camera.proj * vec4f(sample_pos, 1.0);
         let ndcPos = offset.xy / offset.w;
         let uv = ndcPos * vec2f(0.5, -0.5) + vec2f(0.5);
-        let screenCoord = vec2i(uv * screen_size);
+        let screen_coord = vec2i(uv * screen_size);
         let center_coord = vec2i(pixel_mul * pixel_coord);
-        if (all(screenCoord == center_coord)) {
+        if (all(screen_coord == center_coord)) {
             continue;
         }
-        let sampleDepth = textureLoad(positions, screenCoord, 0).z;
-        let depth_diff = abs(fragPos.z - sampleDepth);
-        let rangeCheck = smoothstep(0.0, 1.0, radius / depth_diff);
+        let sample_depth = textureLoad(positions, screen_coord, 0).z;
+        let depth_diff = abs(frag_pos.z - sample_depth);
+        let range_check = smoothstep(0.0, 1.0, radius / depth_diff);
 
         valid += 1.0;
-        occlusion += select(0.0, 1.0, sampleDepth > samplePos.z + 0.03) * rangeCheck;
+        occlusion += select(0.0, 1.0, sample_depth > sample_pos.z + 0.025) * range_check * dot_bias;
     }
 
     occlusion = occlusion / valid;

--- a/renderer-gpu/src/shaders/ssao.wgsl
+++ b/renderer-gpu/src/shaders/ssao.wgsl
@@ -54,7 +54,7 @@ fn compute_ssao(pixel_coord: vec2<u32>, ssao_size: vec2f, screen_size: vec2f) {
 
     let noise_sample_coords = pixel_coord % vec2u(noise_size, noise_size);
     let noise_vec = textureLoad(noise, noise_sample_coords, 0).rgb;
-    let randomVec = (camera.view * vec4f(noise_vec, 0.0)).xyz;
+    let randomVec = noise_vec;
     let tangent = normalize(randomVec - normal * dot(randomVec, normal));
     let bitangent = cross(normal, tangent);
     let TBN = mat3x3(tangent, bitangent, normal);

--- a/renderer-gpu/src/shaders/ssao.wgsl
+++ b/renderer-gpu/src/shaders/ssao.wgsl
@@ -73,6 +73,7 @@ fn compute_ssao(pixel_coord: vec2<u32>, ssao_size: vec2f, screen_size: vec2f) {
         occlusion += select(0.0, 1.0, sample_depth > sample_pos.z + 0.025) * range_check * dot_bias;
     }
 
-    occlusion = occlusion / valid;
+    // valid potentially can be 0.0
+    occlusion = select(0.0, occlusion / valid, valid > 0.0);
     textureStore(ssao_texture, pixel_coord, vec4f(occlusion, 0.0, 0.0, 0.0));
 }

--- a/renderer-gpu/src/shaders/ssao.wgsl
+++ b/renderer-gpu/src/shaders/ssao.wgsl
@@ -25,14 +25,14 @@ fn compute_main(@builtin(global_invocation_id) id: vec3<u32>) {
     compute_ssao(pixel_coord, vec2f(ssao_size), screen_size);
 }
 
-const radius: f32 = 0.35;
+const radius: f32 = 0.5;
 
 const samples: i32 = 16;
 
 const noise_size: u32 = 4;
 
 fn compute_ssao(pixel_coord: vec2<u32>, ssao_size: vec2f, screen_size: vec2f) {
-    let pixel_mul = u32(screen_size.x / ssao_size.x);
+    let pixel_mul = u32(round(screen_size.x / ssao_size.x));
     let loadedNormal = textureLoad(normals, pixel_mul * pixel_coord, 0).xyz;
     if(loadedNormal.y > 0.0) {
         return;
@@ -52,34 +52,29 @@ fn compute_ssao(pixel_coord: vec2<u32>, ssao_size: vec2f, screen_size: vec2f) {
 
     let noise_sample_coords = pixel_coord % vec2u(noise_size, noise_size);
     let noise_vec = textureLoad(noise, noise_sample_coords, 0).rgb;
-    let randomVec = noise_vec;
-    let tangent = normalize(randomVec - normal * dot(randomVec, normal));
+    let tangent = normalize(noise_vec - normal * dot(noise_vec, normal));
     let bitangent = cross(normal, tangent);
     let TBN = mat3x3(tangent, bitangent, normal);
 
     var occlusion = 0.0;
     var valid = 0.0;
     for (var i = 0; i < samples; i++) {
-        var kl = textureLoad(kernel, vec2(i, 0), 0).rgb;
-        let dist_scale = f32(i) / f32(samples);
-
-        let samplePos = fragPos + (TBN * (kl * mix(0.1, 1.0, dist_scale * dist_scale))) * radius;
-
-        let viewSampleDir = normalize(samplePos - fragPos);
-        let ndots = max(dot(normal, viewSampleDir), 0.0);
-        if(ndots == 0.0) {
-            continue;
-        }
+        var kernel = textureLoad(kernel, vec2(i, 0), 0).rgb;
+        let samplePos = fragPos + (TBN * kernel) * radius;
 
         let offset = camera.proj * vec4f(samplePos, 1.0);
         let ndcPos = offset.xy / offset.w;
         let uv = ndcPos * vec2f(0.5, -0.5) + vec2f(0.5);
         let screenCoord = vec2i(uv * screen_size);
+        let center_coord = vec2i(pixel_mul * pixel_coord);
+        if (all(screenCoord == center_coord)) {
+            continue;
+        }
         let sampleDepth = textureLoad(positions, screenCoord, 0).z;
         let rangeCheck = smoothstep(0.0, 1.0, (radius) / abs(fragPos.z - sampleDepth));
 
         valid += 1.0;
-        occlusion += select(0.0, 1.0, sampleDepth > samplePos.z + 0.025) * rangeCheck;
+        occlusion += select(0.0, 1.0, sampleDepth > samplePos.z + 0.03) * rangeCheck;
     }
 
     occlusion = occlusion / valid;

--- a/renderer-gpu/src/shaders/ssao.wgsl
+++ b/renderer-gpu/src/shaders/ssao.wgsl
@@ -57,11 +57,6 @@ fn compute_ssao(pixel_coord: vec2<u32>, ssao_size: vec2f, screen_size: vec2f) {
         let sample_vector = TBN * kernel;
 
         let dot_bias = max(dot(normal, normalize(sample_vector)), 0.0);
-        // fast exit if sample_vector is orthogonal to normal
-        // TODO we can prepare kernel to prevent wasted samples
-        if(dot_bias == 0.0) {
-            continue;
-        }
         let sample_pos = frag_pos + sample_vector * radius;
 
         let offset = camera.proj * vec4f(sample_pos, 1.0);
@@ -72,12 +67,14 @@ fn compute_ssao(pixel_coord: vec2<u32>, ssao_size: vec2f, screen_size: vec2f) {
         if (all(screen_coord == center_coord)) {
             continue;
         }
+        let slope_bias: f32 = max(0.05 * (1.0 - dot_bias), 0.005);
+
         let sample_depth = textureLoad(positions, screen_coord, 0).z;
-        let depth_diff = abs(frag_pos.z - sample_depth);
+        let depth_diff = abs(frag_pos.z - sample_depth) + 0.001;
         let range_check = smoothstep(0.0, 1.0, radius / depth_diff);
 
         valid += 1.0;
-        occlusion += select(0.0, 1.0, sample_depth > sample_pos.z + 0.025) * range_check * dot_bias;
+        occlusion += select(0.0, 1.0, sample_depth >= sample_pos.z + slope_bias) * range_check * dot_bias;
     }
 
     // valid potentially can be 0.0

--- a/renderer-gpu/src/shaders/ssao.wgsl
+++ b/renderer-gpu/src/shaders/ssao.wgsl
@@ -29,6 +29,7 @@ const radius: f32 = 0.5;
 const samples: i32 = 16;
 
 const noise_size: u32 = 4;
+const noise_vec = vec2u(noise_size, noise_size);
 
 fn compute_ssao(pixel_coord: vec2<u32>, ssao_size: vec2f, screen_size: vec2f) {
     let pixel_mul = u32(round(screen_size.x / ssao_size.x));
@@ -37,11 +38,17 @@ fn compute_ssao(pixel_coord: vec2<u32>, ssao_size: vec2f, screen_size: vec2f) {
     let normal = -normalize(loaded_normal);
     let frag_pos = textureLoad(positions, pixel_mul * pixel_coord, 0).xyz;
 
-    let noise_sample_coords = pixel_coord % vec2u(noise_size, noise_size);
+    let noise_sample_coords = pixel_coord % noise_vec;
     let noise_vec = textureLoad(noise, noise_sample_coords, 0).rgb;
-    let tangent = normalize(noise_vec - normal * dot(noise_vec, normal));
-    let bitangent = cross(normal, tangent);
-    let TBN = mat3x3(tangent, bitangent, normal);
+
+    let normal_dot_p = dot(noise_vec, normal);
+    var TBN: mat3x3<f32>;
+    // TODO So far we use Duff's method as a fallback. Further, we could try to combine Duff's with random vector to remove branching.
+    if (normal_dot_p > 0.999) {
+        TBN = duff_onb(normal);
+    } else {
+        TBN = gram_schmidt_onb(normal, noise_vec, normal_dot_p);
+    }
 
     var occlusion = 0.0;
     var valid = 0.0;
@@ -76,4 +83,21 @@ fn compute_ssao(pixel_coord: vec2<u32>, ssao_size: vec2f, screen_size: vec2f) {
     // valid potentially can be 0.0
     occlusion = select(0.0, occlusion / valid, valid > 0.0);
     textureStore(ssao_texture, pixel_coord, vec4f(occlusion, 0.0, 0.0, 0.0));
+}
+
+fn gram_schmidt_onb(normal: vec3<f32>, noise_vec: vec3<f32>, dot_p: f32) -> mat3x3<f32> {
+    let tangent = normalize(noise_vec - normal * dot_p);
+    let bitangent = cross(normal, tangent);
+    return mat3x3(tangent, bitangent, normal);
+}
+
+fn duff_onb(n: vec3<f32>) -> mat3x3<f32> {
+    let s: f32 = select(-1.0, 1.0, n.z >= 0.0);
+    let a: f32 = -1.0 / (s + n.z);
+    let b: f32 = n.x * n.y * a;
+
+    let b1 = vec3<f32>(1.0 + s * n.x * n.x * a, s * b, -s * n.x);
+    let b2 = vec3<f32>(b, s + n.y * n.y * a, -n.y);
+
+    return mat3x3(b1, b2, n);
 }

--- a/renderer-gpu/src/shaders/ssao.wgsl
+++ b/renderer-gpu/src/shaders/ssao.wgsl
@@ -27,11 +27,11 @@ fn compute_main(@builtin(global_invocation_id) id: vec3<u32>) {
     compute_ssao(pixel_coord, vec2f(ssao_size), screen_size);
 }
 
-const radius: f32 = 0.15;
+const radius: f32 = 0.5;
 
 const samples: i32 = 16;
 
-const noise_size: u32 = 64;
+const noise_size: u32 = 4;
 
 fn compute_ssao(pixel_coord: vec2<u32>, ssao_size: vec2f, screen_size: vec2f) {
     let pixel_mul = u32(screen_size.x / ssao_size.x);
@@ -81,11 +81,9 @@ fn compute_ssao(pixel_coord: vec2<u32>, ssao_size: vec2f, screen_size: vec2f) {
 
         let rangeCheck = smoothstep(0.0, 1.0, (radius) / abs(fragPos.z - sampleDepth));
 
-        occlusion += select(0.0, 1.0, sampleDepth > samplePos.z) * rangeCheck * ndots;
+        occlusion += select(0.0, 1.0, sampleDepth > samplePos.z + 0.025) * rangeCheck;
     }
 
-    if(occlusion > 0.0) {
-        occlusion = occlusion / f32(samples);
-        textureStore(ssao_texture, pixel_coord, vec4f(occlusion, 0.0, 0.0, 0.0));
-    }
+    occlusion = occlusion / f32(samples);
+    textureStore(ssao_texture, pixel_coord, vec4f(occlusion, 0.0, 0.0, 0.0));
 }

--- a/renderer-gpu/src/shaders/ssao.wgsl
+++ b/renderer-gpu/src/shaders/ssao.wgsl
@@ -1,18 +1,16 @@
 import super::common::CameraUniform;
 import super::common::frag_pos_from_ray;
 
-@group(0) @binding(0) var ssao_texture: texture_storage_2d<rgba16float, write>;
-
-@group(0) @binding(1) var positions: texture_2d<f32>;
-
-@group(0) @binding(2) var normals: texture_2d<f32>;
-
-@group(0) @binding(3) var noise: texture_2d<f32>;
-
-@group(0) @binding(4) var kernel: texture_2d<f32>;
-
-@group(1) @binding(0)
+@group(0) @binding(0)
 var<uniform> camera: CameraUniform;
+
+@group(1) @binding(0) var ssao_texture: texture_storage_2d<rgba16float, write>;
+
+@group(1) @binding(1) var positions: texture_2d<f32>;
+@group(1) @binding(2) var normals: texture_2d<f32>;
+
+@group(1) @binding(3) var noise: texture_2d<f32>;
+@group(1) @binding(4) var kernel: texture_2d<f32>;
 
 @compute @workgroup_size(8, 8, 1)
 fn compute_main(@builtin(global_invocation_id) id: vec3<u32>) {


### PR DESCRIPTION
## Summary
1. Fixed #194 
2. Improved math and SSAO pre-generated resources(kernel, TBN noise).
3. Introduced a fake ground for GBuf instead of messy logic simulating it inside SSAO.
4. Improved SSAO blur, it's aligned with SSAO itself.
5. Used 32 bits texture for positions to reduce large plane acne.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated ground-layer rendering for improved scene composition.
  * Improved support for scenes and previews without assigned textures.
  * Enhanced ambient occlusion with more consistent full-resolution shading and improved sampling.

* **Bug Fixes**
  * Improved G-buffer precision for more accurate positioning and surface details.
  * Refined screen texture filtering to produce smoother, more consistent results.
  * Improved rendering behavior across different display scales and platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->