### PR TITLE
Fix wgpu validation panic on every render frame

### DIFF
--- a/ffi-run/src/lib.rs
+++ b/ffi-run/src/lib.rs
@@ -36,9 +36,13 @@ impl From<RouteCosting> for map::route::RouteCosting {
 #[uniffi::export]
 impl ShashlikMapApi {
     fn render(&self) {
-        let mut shashlik_map = self.shashlik_map.write().unwrap();
-        // TODO handle result
-        shashlik_map.update_and_render(());
+        // Use write() + recover-from-poison so a single bad frame doesn't permanently
+        // brick every subsequent render via a poisoned RwLock.
+        let mut guard = match self.shashlik_map.write() {
+            Ok(g) => g,
+            Err(e) => e.into_inner(),
+        };
+        guard.update_and_render(());
     }
 
     fn resize(&self, width: u32, height: u32) {

--- a/renderer-gpu/src/global_context.rs
+++ b/renderer-gpu/src/global_context.rs
@@ -29,19 +29,30 @@ impl GlobalContext {
         let view_projection = ViewProjection::new(device, render_config);
         let collider = Collider::new();
         let styles_bind_group_layout = Self::create_style_bind_group_layout(device);
-        
         let texture_view_resources = TextureViewResources::new(render_config, device);
+
+        // subscribe() sends the current style snapshot immediately on the channel.
+        // Consume it right here — before run_background() spawns, so no race is possible —
+        // to guarantee style_bind_group is Some before the very first draw call.
+        // wgpu 30+ panics on uncaptured validation errors, so a None bind group at group 1
+        // during any draw would panic, poison the RwLock, and break every subsequent frame.
+        let mut style_uniform_rx = style_store.subscribe();
+        let style_bind_group = style_uniform_rx
+            .try_recv()
+            .ok()
+            .map(|uniforms| Self::create_styles_bind_group(device, &styles_bind_group_layout, &uniforms));
+
         GlobalContext {
             canvas,
             view_projection,
             collider,
             styles_bind_group_layout,
-            style_bind_group: None,
+            style_bind_group,
             ssao_enabled: render_config.ssao_enabled,
             x_real_mesh_shader_enabled: render_config.x_real_mesh_shader_enabled,
             texture_view_resources,
             preview_type: render_config.preview_type,
-            style_uniform_rx: style_store.subscribe(),
+            style_uniform_rx,
         }
     }
 
@@ -86,26 +97,27 @@ impl GlobalContext {
         self.x_real_mesh_shader_enabled = render_config.x_real_mesh_shader_enabled;
     }
 
+    fn create_styles_bind_group(device: &Device, layout: &BindGroupLayout, uniforms: &[[[f32; 4]; 4]]) -> BindGroup {
+        // TODO We could reuse the buffer if styles count has not changed
+        let styles_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("Style Buffer"),
+            contents: bytemuck::cast_slice(uniforms),
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+        });
+        device.create_bind_group(&wgpu::BindGroupDescriptor {
+            layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: styles_buffer.as_entire_binding(),
+            }],
+            label: Some("styles_bind_group"),
+        })
+    }
+
     fn update_style_bind_group(&mut self) {
-        let device = self.canvas.device();
         if let Ok(uniforms) = self.style_uniform_rx.no_lagged() {
-            // TODO We could reuse the buffer if styles count has not changed
-            let styles_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-                label: Some("Style Buffer"),
-                contents: bytemuck::cast_slice(&uniforms),
-                usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
-            });
-
-            let styles_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
-                layout: &self.styles_bind_group_layout,
-                entries: &[wgpu::BindGroupEntry {
-                    binding: 0,
-                    resource: styles_buffer.as_entire_binding(),
-                }],
-                label: Some("styles_bind_group"),
-            });
-
-            self.style_bind_group = Some(styles_bind_group);
+            let device = self.canvas.device();
+            self.style_bind_group = Some(Self::create_styles_bind_group(device, &self.styles_bind_group_layout, &uniforms));
         }
     }
 


### PR DESCRIPTION
## Problem

In wgpu 30+, uncaptured validation errors **panic by default**. `style_bind_group` (the GPU styles storage buffer at bind group index 1) was initialized as `None` in `GlobalContext::new()` and only populated lazily when the first broadcast from `StyleStore` was consumed in `update_style_bind_group()`.

Any draw call reaching `ShapePipeline::setup_render` before that first broadcast caused a **`MissingBindGroup` validation error → panic**. Once the first panic fired, the `RwLock<ShashlikMap>` became poisoned, causing every subsequent `render()` call to also panic via `write().unwrap()`.

## Fix

**`renderer-gpu/src/global_context.rs`**
- `StyleStore::subscribe()` synchronously sends the current style snapshot onto the broadcast channel before returning. We now consume that message immediately inside `GlobalContext::new()` — before `run_background()` even spawns the background thread, so there is no race — guaranteeing `style_bind_group` is `Some(...)` before the very first draw call.
- Extracted `create_styles_bind_group()` helper shared between `new()` and `update_style_bind_group()`.

**`ffi-run/src/lib.rs`**
- `render()` now recovers from a poisoned `RwLock` via `PoisonError::into_inner()` instead of `.unwrap()`. This is defence-in-depth — Fix 1 prevents poisoning in normal operation, but this ensures one unexpected panic can never permanently brick all subsequent renders.

## Test plan
- [ ] Render loop runs without validation errors on first frame
- [ ] Subsequent frames continue rendering if an earlier frame had an error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved rendering stability when recovering from an internal state-lock issue.
  - Prevented failures that could interrupt map rendering.

- **Visual Improvements**
  - Styles are now applied correctly during initial rendering.
  - Style updates are reflected more reliably as they change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->