### PR TITLE
Add draw_track / clear_track for arbitrary GPS track rendering

### DIFF
--- a/docs/arbitrary-track-rendering.md
+++ b/docs/arbitrary-track-rendering.md
@@ -1,0 +1,182 @@
+# Arbitrary Track Rendering
+
+## Context
+
+`TripHistoryPoC` needs to display pre-recorded GPS tracks on the map — on trip detail screens and
+optionally as a live trail during recording. These are raw or map-matched coordinate sequences
+fetched from a server, not Valhalla-routed paths.
+
+The current `ShashlikMapApi` has no method to draw an arbitrary polyline. `calculate_route_to_lat_lon`
+is unsuitable because it produces a freshly-routed path, not the recorded one.
+
+---
+
+## Requirement
+
+Expose two methods on `ShashlikMapApi` (via uniffi):
+
+```kotlin
+fun drawTrack(points: List<LatLon>)
+fun clearTrack()
+```
+
+**Behaviour:**
+- `drawTrack` replaces any previously drawn track on the next render call
+- Rendered as a continuous polyline, visually distinct from Valhalla routes
+- `clearTrack` removes it
+- No camera movement — the caller manages the viewport via `setLatLonBearing` or gestures
+- Safe to call at GPS update frequency (1 Hz) for live trail use cases
+
+---
+
+## Implementation Plan
+
+### Files to change
+
+| File | Change |
+|---|---|
+| `map/src/track_group.rs` | New — `TrackGroup` render group |
+| `map/src/lib.rs` | Add `draw_track` / `clear_track` to `ShashlikMap` |
+| `ffi-run/src/lib.rs` | Add `LatLon` record + two uniffi methods to `ShashlikMapApi` |
+
+No changes needed outside the `map` and `ffi-run` crates.
+
+---
+
+### Step 1 — `TrackGroup` (`map/src/track_group.rs`)
+
+A new struct implementing `RenderGroup`, structurally similar to `RouteGroup` for car/motorbike
+(the Lyon polyline path, no pedestrian dotted variant needed).
+
+Key details:
+- Points are stored as `Vec<Point>` in world space (already converted from lon/lat by the caller)
+- The path is built relative to `first_point()` — same floating-point precision pattern used in
+  `RouteGroup` — to avoid large absolute world coordinates on the GPU
+- `SpatialData::transform(first_point())` carries the absolute world offset
+- Style ID: `"track"` (see Step 2 for registration)
+- Feature layer tag: `"kml_layer"` — already a non-indirect default feature layer that renders
+  after tile geometry, giving correct z-ordering for free with no new layer registration needed
+
+```rust
+pub struct TrackGroup {
+    points: Vec<Point>,
+}
+
+impl TrackGroup {
+    pub fn new(points: Vec<Point>) -> Self { ... }
+    pub fn first_point(&self) -> DVec3 { ... }
+}
+
+impl<T: CanvasApi> RenderGroup<T> for TrackGroup {
+    fn content(&mut self, canvas: &mut T) {
+        canvas.set_feature_layer_tag(Some("kml_layer".to_string()));
+        // build Lyon path relative to first_point, submit as GeometryData::Shape polyline
+    }
+}
+```
+
+---
+
+### Step 2 — Style registration (`map/src/lib.rs`, `ShashlikMap::new`)
+
+`StyleStore::get_index` silently inserts a default style for unknown IDs, so the track renders
+immediately even without explicit registration. To give it a distinct appearance, register the
+style once in `ShashlikMap::new` alongside the existing puck setup:
+
+```rust
+renderer.api().update_style(StyleId::new("track"), |s| {
+    *s = RenderStyle::fill([0.2, 0.5, 1.0, 0.85]); // blue, visually distinct from route orange
+});
+```
+
+No external `osm` crate change required. The feature is fully self-contained.
+
+---
+
+### Step 3 — `draw_track` / `clear_track` on `ShashlikMap` (`map/src/lib.rs`)
+
+Two methods added directly to `ShashlikMap`, at the same level as `clear_routes` and `load_kml_path`.
+No `TrackController` wrapper — unlike routing, there is no async work, no retry, no alternatives
+counter, and no warm-up concern. The logic is:
+
+```rust
+pub fn draw_track(&mut self, lon_lats: Vec<(f64, f64)>) {
+    self.renderer.api().clear_render_groups(HashSet::from(["track".to_string()]));
+    let converter = self.create_location_coord_converter();
+    let points: Vec<Point> = lon_lats.iter()
+        .map(|(lon, lat)| converter(&Point::new(*lon, *lat)))
+        .collect();
+    let group = TrackGroup::new(points);
+    self.renderer.api().add_render_group(
+        "track".to_string(),
+        SpatialData::transform(group.first_point()),
+        Box::new(group),
+    );
+}
+
+pub fn clear_track(&mut self) {
+    self.renderer.api().clear_render_groups(HashSet::from(["track".to_string()]));
+}
+```
+
+Note: `clear_render_groups` before `add_render_group` is required for replace semantics.
+The `spatial_data_map` entry is overwritten by key, but GPU layer buffers are not automatically
+evicted — explicit clearing is necessary (same pattern as `RouteController::clear_routes`).
+
+---
+
+### Step 4 — uniffi surface (`ffi-run/src/lib.rs`)
+
+Add a `LatLon` record and two exported methods:
+
+```rust
+#[derive(uniffi::Record)]
+pub struct LatLon {
+    pub lat: f64,
+    pub lon: f64,
+}
+
+#[uniffi::export]
+impl ShashlikMapApi {
+    fn draw_track(&self, points: Vec<LatLon>) {
+        let mut map = self.shashlik_map.write().unwrap();
+        let lon_lats: Vec<(f64, f64)> = points.iter().map(|p| (p.lon, p.lat)).collect();
+        map.draw_track(lon_lats);
+    }
+
+    fn clear_track(&self) {
+        let mut map = self.shashlik_map.write().unwrap();
+        map.clear_track();
+    }
+}
+```
+
+uniffi generates the Kotlin data class `LatLon` and the two methods automatically.
+
+---
+
+## What this does NOT change
+
+- `renderer-common` — no new feature layer tag
+- `renderer-gpu` — no pipeline or pass node changes
+- `app-surface`, `winit-run`, `kmp` — no changes
+- External `osm`/`shashlik-tiles-gen-v0` crate — no style loader change needed
+
+---
+
+## Live trail usage pattern
+
+The API supports incremental live trail by design. The caller accumulates points and replaces
+the track each GPS update:
+
+```kotlin
+val trackPoints = mutableListOf<LatLon>()
+
+fun onGpsUpdate(lat: Double, lon: Double) {
+    trackPoints.add(LatLon(lat, lon))
+    shashlikMapApi?.drawTrack(trackPoints)
+}
+```
+
+Re-tessellation of a typical GPS track (hundreds of points) takes microseconds on the CPU side.
+At 1 Hz this is negligible.

--- a/ffi-run/src/lib.rs
+++ b/ffi-run/src/lib.rs
@@ -18,6 +18,12 @@ pub struct ShashlikMapApi {
 unsafe impl Sync for ShashlikMapApi {}
 unsafe impl Send for ShashlikMapApi {}
 
+#[derive(uniffi::Record)]
+pub struct LatLon {
+    pub lat: f64,
+    pub lon: f64,
+}
+
 #[derive(uniffi::Enum)]
 pub enum RouteCosting {
     Auto, Pedestrian, Motorbike
@@ -106,5 +112,16 @@ impl ShashlikMapApi {
     fn calculate_route(&self, point_x: f32, point_y: f32, route_costing: RouteCosting) {
         let mut shashlik_map = self.shashlik_map.write().unwrap();
         shashlik_map.create_route_to_screen_point(point_x, point_y, route_costing.into());
+    }
+
+    fn draw_track(&self, points: Vec<LatLon>) {
+        let mut shashlik_map = self.shashlik_map.write().unwrap();
+        let lon_lats: Vec<(f64, f64)> = points.iter().map(|p| (p.lon, p.lat)).collect();
+        shashlik_map.draw_track(lon_lats);
+    }
+
+    fn clear_track(&self) {
+        let mut shashlik_map = self.shashlik_map.write().unwrap();
+        shashlik_map.clear_track();
     }
 }

--- a/kmp/shared/build.gradle.kts
+++ b/kmp/shared/build.gradle.kts
@@ -100,7 +100,9 @@ version = "0.2.1"
 mavenPublishing {
     publishToMavenCentral()
 
-    signAllPublications()
+    if (!project.hasProperty("skipSigning")) {
+        signAllPublications()
+    }
 
     coordinates(group.toString(), "mapshared", version.toString())
 

--- a/map/src/lib.rs
+++ b/map/src/lib.rs
@@ -21,6 +21,7 @@ use renderer_common::style_id::StyleId;
 use route::route_controller::RouteController;
 #[cfg(feature = "sgnss")]
 use sgnss::start_sgnss;
+use std::collections::HashSet;
 use std::mem;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -30,6 +31,7 @@ use std::thread::{sleep, spawn};
 use std::time::{Duration, Instant};
 use log::error;
 use renderer_common::{CanvasApi, RendererApi, Renderer, RendererUpdateData};
+use crate::track_group::TrackGroup;
 use crate::transition_2d_3d_helper::Transition2d3dHelper;
 
 mod camera;
@@ -38,6 +40,7 @@ mod kml_viewer_group;
 pub mod mesh_loader;
 mod puck_group;
 pub mod route;
+mod track_group;
 pub mod tiles;
 mod transition_2d_3d_helper;
 
@@ -120,6 +123,7 @@ impl<R: Renderer, T: TilesProvider + Sync> ShashlikMap<R, T> {
         let transition_2d_3d_helper = Transition2d3dHelper::new(zero_zoom_level_loaded.clone());
         Self::run_tiles(renderer.api(), zero_zoom_level_loaded.clone(), tiles_stream);
         Self::load_styles(renderer.api());
+        Self::register_track_style(renderer.api());
 
         let mut camera_controller = CameraController::new();
         camera_controller.pitch = CameraController::MIN_PITCH;
@@ -526,6 +530,34 @@ impl<R: Renderer, T: TilesProvider + Sync> ShashlikMap<R, T> {
     pub fn clear_routes(&mut self) {
         self.route_controller
             .clear_routes(self.renderer.api());
+    }
+
+    fn register_track_style(renderer_api: Arc<R::RAPI>) {
+        renderer_api.update_style(StyleId::new("track"), |style| {
+            *style = renderer_common::render_style::RenderStyle::fill([0.2, 0.5, 1.0, 0.85]);
+        });
+    }
+
+    pub fn draw_track(&mut self, lon_lats: Vec<(f64, f64)>) {
+        self.renderer.api().clear_render_groups(HashSet::from(["track".to_string()]));
+        if lon_lats.len() < 2 {
+            return;
+        }
+        let converter = self.create_location_coord_converter();
+        let points: Vec<geo_types::Point> = lon_lats
+            .iter()
+            .map(|(lon, lat)| converter(&geo_types::Point::new(*lon, *lat)))
+            .collect();
+        let group = TrackGroup::new(points);
+        self.renderer.api().add_render_group(
+            "track".to_string(),
+            SpatialData::transform(group.first_point()),
+            Box::new(group),
+        );
+    }
+
+    pub fn clear_track(&mut self) {
+        self.renderer.api().clear_render_groups(HashSet::from(["track".to_string()]));
     }
 
     #[allow(unused_variables)]

--- a/map/src/track_group.rs
+++ b/map/src/track_group.rs
@@ -1,0 +1,56 @@
+use geo_types::Point;
+use glam::DVec3;
+use lyon::geom::point;
+use lyon::lyon_tessellation::{LineCap, LineJoin};
+use lyon::path::Path;
+use renderer_common::geometry_data::{GeometryData, GeometryType, PolylineOptions, ShapeData, StyledRangeInfo};
+use renderer_common::render_group::RenderGroup;
+use renderer_common::style_id::StyleId;
+use renderer_common::CanvasApi;
+
+pub struct TrackGroup {
+    points: Vec<Point>,
+}
+
+impl TrackGroup {
+    pub fn new(points: Vec<Point>) -> Self {
+        TrackGroup { points }
+    }
+
+    pub fn first_point(&self) -> DVec3 {
+        DVec3::new(self.points[0].x(), self.points[0].y(), 0.0)
+    }
+}
+
+impl<T: CanvasApi> RenderGroup<T> for TrackGroup {
+    fn content(&mut self, canvas: &mut T) {
+        canvas.set_feature_layer_tag(Some("kml_layer".to_string()));
+
+        let first = self.points[0];
+        let mut path_builder = Path::builder();
+        path_builder.begin(point(0.0f32, 0.0f32));
+
+        for &p in self.points[1..].iter() {
+            path_builder.line_to(point(
+                (p.x() - first.x()) as f32,
+                (p.y() - first.y()) as f32,
+            ));
+        }
+        path_builder.end(false);
+
+        let options = PolylineOptions {
+            width: 1.2f32,
+            line_join: LineJoin::Round,
+            line_cap: LineCap::Round,
+            tolerance: 0.01f32,
+        };
+
+        canvas.geometry_data(GeometryData::Shape(ShapeData {
+            path: path_builder.build(),
+            geometry_type: GeometryType::Polyline(options),
+            style_id: StyleId::new("track"),
+            index_layer_level: 0,
+            styled_range_info: StyledRangeInfo::default(),
+        }));
+    }
+}


### PR DESCRIPTION
## Summary

Exposes two new methods on `ShashlikMapApi` (via uniffi) for rendering an arbitrary ordered sequence of GPS coordinates as a styled polyline — intended for live navigation trails, trip history overlays, and similar use cases.

- `draw_track(points: Vec<LatLon>)` — tessellates the coordinate sequence as a blue polyline, replacing any previously drawn track
- `clear_track()` — removes the track from the map

## Implementation

- **`map/src/track_group.rs`** — new `TrackGroup` implementing `RenderGroup` using Lyon stroke tessellation; reuses the existing `kml_layer` feature layer so the track renders above tile geometry without touching `renderer-common`
- **`map/src/lib.rs`** — `draw_track`, `clear_track`, and `register_track_style` (called once at init to pre-register the `"track"` style as a solid blue fill)
- **`ffi-run/src/lib.rs`** — `LatLon` uniffi record + `draw_track`/`clear_track` exported methods
- **`kmp/shared/build.gradle.kts`** — `signAllPublications()` is now conditional on `-PskipSigning`, allowing `publishToMavenLocal` for local development without a GPG keyring
- **`docs/arbitrary-track-rendering.md`** — full approach document

## Design decisions

- Reuses `kml_layer` instead of a new feature layer — no `renderer-common` changes needed
- Style registered directly in Rust at startup — no dependency on the `osm` style loader
- No `TrackController` struct — simpler than `RouteController`; a `HashMap` key `"track"` in the render group map is sufficient

## Test plan
- [ ] `drawTrack(listOf(LatLon(...), ...))` renders a blue polyline over the map
- [ ] Calling `drawTrack` again replaces the previous track (no accumulation)
- [ ] `clearTrack()` removes the polyline
- [ ] No regression on existing tile rendering, route, or puck features

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for drawing GPS tracks on the map from latitude/longitude points.
  - Added controls to replace an existing track or clear it entirely.
  - Tracks render as blue, rounded lines with consistent styling.
  - Added camera behavior and live-trail guidance for track rendering.

- **Documentation**
  - Documented track drawing, clearing, replacement behavior, styling, layering, and camera semantics.

- **Chores**
  - Maven publication signing can now be skipped when explicitly configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->