### PR TITLE
TechDebt. Update building height logic

### DIFF
--- a/map/Cargo.toml
+++ b/map/Cargo.toml
@@ -21,7 +21,6 @@ geo = "0.33.1"
 seahash = "4.1.0"
 rayon = "1.11.0"
 kml = { git = "https://github.com/ShashlikMap/kml" }
-rand = { workspace = true }
 fast-mvt = "0.4"
 
 glam = { workspace = true }

--- a/map/src/feature_processor.rs
+++ b/map/src/feature_processor.rs
@@ -7,7 +7,6 @@ use osm::map::{
     HighwayKind, LayerKind, LineKind, MapGeomObjectKind, MapPointInfo, MapPointObjectKind,
     NatureKind,
 };
-use rand::RngExt;
 use renderer_common::geometry_data::{ExtrudedPolygonData, GeometryData, GeometryType, LineData, PolylineOptions, ShapeData, StyledRangeInfo, SvgBackground, SvgData, TextData};
 use renderer_common::style_id::StyleId;
 use seahash::hash;
@@ -291,7 +290,8 @@ impl FeatureProcessor for ShashlikFeatureProcessor {
                     let mut styled_range_info = StyledRangeInfo::new(1, true);
                     if zoom_level == 0 && self.include_extruded {
                         let level = if level == 0 {
-                            rand::rng().random_range(2..=3)
+                            let (point, _) = building_path.first_endpoint().unwrap_or_default();
+                            (((point.x as i32 * point.y as i32) % 2) + 2) as u16
                         } else {
                             level
                         };

--- a/map/src/feature_processor.rs
+++ b/map/src/feature_processor.rs
@@ -291,7 +291,7 @@ impl FeatureProcessor for ShashlikFeatureProcessor {
                     if zoom_level == 0 && self.include_extruded {
                         let level = if level == 0 {
                             let (point, _) = building_path.first_endpoint().unwrap_or_default();
-                            (((point.x as i32 * point.y as i32) % 2) + 2) as u16
+                            (((point.x.abs() as i32 * point.y.abs() as i32) % 2) + 2) as u16
                         } else {
                             level
                         };


### PR DESCRIPTION
## Summary
Building extrusion level are now generated deterministically for cases when there is no height data.
It should resolve screenshot test issues.